### PR TITLE
feat(serving): FastAPI serving layer with MLflow alias loading

### DIFF
--- a/src/serving/app.py
+++ b/src/serving/app.py
@@ -1,0 +1,144 @@
+"""FastAPI application for HDB resale price prediction.
+
+Endpoints
+---------
+POST /predict       — single-flat resale price prediction
+POST /explain       — SHAP feature contributions (stub, returns 501)
+GET  /health        — service liveness and model load status
+GET  /model-info    — metadata for the currently loaded model version
+"""
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from serving.config import ServingConfig
+from serving.logging_config import configure_logging
+from serving.model_loader import ModelLoader
+from serving.schemas import (
+    ExplainRequest,
+    HDBFeatureInput,
+    HealthResponse,
+    ModelInfoResponse,
+    PredictRequest,
+    PredictResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+config = ServingConfig()
+loader = ModelLoader(config)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    configure_logging()
+    loader.load_initial()
+    loader.start_background_polling()
+    yield
+
+
+app = FastAPI(
+    title="HDB Resale Price Predictor",
+    description=(
+        "Serves the @champion GradientBoostingRegressor from the MLflow registry. "
+        "The model is swapped automatically when the @champion alias is reassigned."
+    ),
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+def _build_feature_dataframe(req: HDBFeatureInput) -> pd.DataFrame:
+    """Convert a feature request into the DataFrame expected by the sklearn pipeline.
+
+    Applies the same normalisation as load_and_prepare_data in the training
+    script: town and storey_range uppercased, flat_info derived from
+    flat_type + flat_model, float_time_series derived from month string.
+    """
+    year_str, month_str = req.month.split("-")
+    float_time_series = int(year_str) + (int(month_str) - 1) / 12.0
+    flat_info = f"{req.flat_type.strip().upper()} {req.flat_model.strip().title()}"
+
+    return pd.DataFrame(
+        [
+            {
+                "floor_area_sqm": req.floor_area_sqm,
+                "lease_commence_date": req.lease_commence_date,
+                "float_time_series": float_time_series,
+                "town": req.town.strip().upper(),
+                "storey_range": req.storey_range.strip().upper(),
+                "flat_info": flat_info,
+            }
+        ]
+    )
+
+
+@app.post("/predict", response_model=PredictResponse)
+async def predict(req: PredictRequest) -> PredictResponse:
+    """Return a resale price prediction for a single HDB flat.
+
+    The serving model is the current @champion version. The background reload
+    thread swaps it within 60 seconds of a promotion event, so the version
+    field in the response may change between calls after a promotion.
+    """
+    model = loader.get_model()
+    version = loader.get_version()
+    df = _build_feature_dataframe(req)
+    try:
+        prediction = float(model.predict(df)[0])  # type: ignore[index]
+    except Exception as exc:
+        logger.exception("Prediction failed for request: %s", req.model_dump())
+        raise HTTPException(status_code=500, detail="Prediction failed.") from exc
+
+    return PredictResponse(
+        predicted_resale_price=round(prediction, 2),
+        model_version=version or "unknown",
+        model_alias=config.model_alias,
+    )
+
+
+@app.post("/explain")
+async def explain(req: ExplainRequest) -> JSONResponse:
+    """Return SHAP feature contributions for a single prediction.
+
+    SHAP TreeExplainer integration is pending. The request schema is validated
+    now so the contract is established; the response body will be replaced with
+    per-feature contributions in the next serving task.
+    """
+    return JSONResponse(
+        status_code=501,
+        content={
+            "detail": (
+                "SHAP explainability is not yet implemented. "
+                "TreeExplainer integration is tracked as a separate task and "
+                "will replace this stub in the next iteration."
+            )
+        },
+    )
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Return service liveness and current model load status."""
+    version = loader.get_version()
+    return HealthResponse(
+        status="ok",
+        model_loaded=version is not None,
+        model_version=version,
+    )
+
+
+@app.get("/model-info", response_model=ModelInfoResponse)
+async def model_info() -> ModelInfoResponse:
+    """Return provenance metadata for the currently loaded model version."""
+    return ModelInfoResponse(
+        model_name=config.model_name,
+        model_alias=config.model_alias,
+        model_version=loader.get_version(),
+        run_id=loader.get_run_id(),
+    )

--- a/src/serving/app.py
+++ b/src/serving/app.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import pandas as pd
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from serving.config import ServingConfig
@@ -88,6 +88,11 @@ async def predict(req: PredictRequest) -> PredictResponse:
     """
     model = loader.get_model()
     version = loader.get_version()
+    if version is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Model not loaded yet — try again shortly",
+        )
     df = _build_feature_dataframe(req)
     try:
         prediction = float(model.predict(df)[0])  # type: ignore[index]
@@ -97,7 +102,7 @@ async def predict(req: PredictRequest) -> PredictResponse:
 
     return PredictResponse(
         predicted_resale_price=round(prediction, 2),
-        model_version=version or "unknown",
+        model_version=version,
         model_alias=config.model_alias,
     )
 

--- a/src/serving/config.py
+++ b/src/serving/config.py
@@ -1,0 +1,17 @@
+"""Serving configuration loaded from environment variables."""
+
+from pydantic_settings import BaseSettings
+
+
+class ServingConfig(BaseSettings):
+    """Configuration for the FastAPI serving application.
+
+    All fields are overridable via environment variables of the same name
+    (case-insensitive). In deployment, set MLFLOW_TRACKING_URI to point at
+    the shared tracking server running alongside the serving pod.
+    """
+
+    mlflow_tracking_uri: str = "sqlite:///mlflow.db"
+    model_name: str = "hdb-predictor"
+    model_alias: str = "champion"
+    reload_interval_seconds: int = 60

--- a/src/serving/logging_config.py
+++ b/src/serving/logging_config.py
@@ -1,0 +1,18 @@
+"""Logging configuration for the serving application."""
+
+import logging
+import sys
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger with a structured format suitable for stdout collection.
+
+    Args:
+        level: Logging level for the root logger. Defaults to INFO.
+    """
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
+    root = logging.getLogger()
+    if not root.handlers:
+        root.addHandler(handler)
+    root.setLevel(level)

--- a/src/serving/model_loader.py
+++ b/src/serving/model_loader.py
@@ -36,7 +36,7 @@ class ModelLoader:
         self._config = config
         self._lock = threading.Lock()
         self._model: PyFuncModel | None = None
-        self._current_version: str | None = None
+        self._current_version: int | None = None
         mlflow.set_tracking_uri(config.mlflow_tracking_uri)
         self._client = MlflowClient()
 
@@ -81,7 +81,7 @@ class ModelLoader:
                 raise RuntimeError("Model not yet loaded; startup may have failed.")
             return self._model
 
-    def get_version(self) -> str | None:
+    def get_version(self) -> int | None:
         """Return the version string of the currently loaded model."""
         with self._lock:
             return self._current_version
@@ -117,7 +117,7 @@ class ModelLoader:
             self._config.reload_interval_seconds,
         )
 
-    def _resolve_alias_version(self) -> str:
+    def _resolve_alias_version(self) -> int:
         """Return the model version currently pointed to by the configured alias."""
         mv = self._client.get_model_version_by_alias(
             self._config.model_name, self._config.model_alias

--- a/src/serving/model_loader.py
+++ b/src/serving/model_loader.py
@@ -15,6 +15,7 @@ import time
 import mlflow
 import mlflow.pyfunc
 from mlflow import MlflowClient
+from mlflow.pyfunc import PyFuncModel
 
 from serving.config import ServingConfig
 
@@ -34,7 +35,7 @@ class ModelLoader:
     def __init__(self, config: ServingConfig) -> None:
         self._config = config
         self._lock = threading.Lock()
-        self._model: mlflow.pyfunc.PyFuncModel | None = None
+        self._model: PyFuncModel | None = None
         self._current_version: str | None = None
         mlflow.set_tracking_uri(config.mlflow_tracking_uri)
         self._client = MlflowClient()
@@ -66,7 +67,7 @@ class ModelLoader:
             version,
         )
 
-    def get_model(self) -> mlflow.pyfunc.PyFuncModel:
+    def get_model(self) -> PyFuncModel:
         """Return the currently loaded model.
 
         Returns:

--- a/src/serving/model_loader.py
+++ b/src/serving/model_loader.py
@@ -1,0 +1,160 @@
+"""Background model loader with atomic swap for zero-downtime model updates.
+
+The serving app calls load_initial() at startup to fetch the champion model
+synchronously, then start_background_polling() to spawn a daemon thread that
+checks the registry every RELOAD_INTERVAL_SECONDS. When the @champion alias
+points to a new version, the daemon loads it and swaps the in-memory reference
+under a threading.Lock. In-flight predictions hold a reference to the old model
+object and complete safely; the old object is GC'd once no references remain.
+"""
+
+import logging
+import threading
+import time
+
+import mlflow
+import mlflow.pyfunc
+from mlflow import MlflowClient
+
+from serving.config import ServingConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ModelLoader:
+    """Loads the champion model from MLflow registry and polls for version changes.
+
+    Thread safety: _model and _current_version are only mutated inside
+    self._lock. The model load itself happens outside the lock — loading is
+    slow and blocking predictions during it would be unacceptable. Python's
+    reference counting guarantees the old model stays alive until all
+    in-flight predictions that hold a reference to it finish.
+    """
+
+    def __init__(self, config: ServingConfig) -> None:
+        self._config = config
+        self._lock = threading.Lock()
+        self._model: mlflow.pyfunc.PyFuncModel | None = None
+        self._current_version: str | None = None
+        mlflow.set_tracking_uri(config.mlflow_tracking_uri)
+        self._client = MlflowClient()
+
+    def load_initial(self) -> None:
+        """Synchronously load the champion model at application startup.
+
+        Intentionally raises on failure so the app fails fast rather than
+        starting in a state where /predict immediately returns 500.
+
+        Raises:
+            Exception: Any MLflow error from alias resolution or model download.
+        """
+        logger.info(
+            "Loading %s@%s from %s",
+            self._config.model_name,
+            self._config.model_alias,
+            self._config.mlflow_tracking_uri,
+        )
+        version = self._resolve_alias_version()
+        model_uri = f"models:/{self._config.model_name}@{self._config.model_alias}"
+        model = mlflow.pyfunc.load_model(model_uri)
+        with self._lock:
+            self._model = model
+            self._current_version = version
+        logger.info(
+            "Loaded %s version %s",
+            self._config.model_name,
+            version,
+        )
+
+    def get_model(self) -> mlflow.pyfunc.PyFuncModel:
+        """Return the currently loaded model.
+
+        Returns:
+            The active PyFuncModel instance.
+
+        Raises:
+            RuntimeError: If called before load_initial() has succeeded.
+        """
+        with self._lock:
+            if self._model is None:
+                raise RuntimeError("Model not yet loaded; startup may have failed.")
+            return self._model
+
+    def get_version(self) -> str | None:
+        """Return the version string of the currently loaded model."""
+        with self._lock:
+            return self._current_version
+
+    def get_run_id(self) -> str | None:
+        """Return the MLflow run ID associated with the currently loaded version.
+
+        Returns None if the version is unknown or the registry call fails.
+        """
+        version = self.get_version()
+        if version is None:
+            return None
+        try:
+            mv = self._client.get_model_version(self._config.model_name, version)
+            return mv.run_id
+        except Exception:
+            logger.exception("Failed to fetch run ID for version %s", version)
+            return None
+
+    def start_background_polling(self) -> None:
+        """Spawn a daemon thread that polls the registry on RELOAD_INTERVAL_SECONDS.
+
+        The thread is a daemon so it does not prevent interpreter shutdown.
+        """
+        thread = threading.Thread(
+            target=self._poll_loop,
+            name="model-reload-poller",
+            daemon=True,
+        )
+        thread.start()
+        logger.info(
+            "Background polling started (interval=%ds)",
+            self._config.reload_interval_seconds,
+        )
+
+    def _resolve_alias_version(self) -> str:
+        """Return the model version currently pointed to by the configured alias."""
+        mv = self._client.get_model_version_by_alias(
+            self._config.model_name, self._config.model_alias
+        )
+        return mv.version
+
+    def _reload_if_changed(self) -> None:
+        """Check the registry and swap the in-memory model if the alias moved."""
+        try:
+            latest_version = self._resolve_alias_version()
+            with self._lock:
+                unchanged = latest_version == self._current_version
+            if unchanged:
+                return
+
+            logger.info(
+                "Alias @%s moved to version %s; loading...",
+                self._config.model_alias,
+                latest_version,
+            )
+            model_uri = f"models:/{self._config.model_name}@{self._config.model_alias}"
+            new_model = mlflow.pyfunc.load_model(model_uri)
+            with self._lock:
+                self._model = new_model
+                self._current_version = latest_version
+            logger.info(
+                "Model swapped: %s now at version %s",
+                self._config.model_name,
+                latest_version,
+            )
+        except Exception:
+            logger.exception(
+                "Background reload failed; continuing with version %s",
+                self._current_version,
+            )
+
+    def _poll_loop(self) -> None:
+        """Blocking loop executed inside the background daemon thread."""
+        while True:
+            time.sleep(self._config.reload_interval_seconds)
+            self._reload_if_changed()

--- a/src/serving/schemas.py
+++ b/src/serving/schemas.py
@@ -31,7 +31,7 @@ class PredictResponse(BaseModel):
     """Prediction result with model provenance."""
 
     predicted_resale_price: float
-    model_version: str
+    model_version: int
     model_alias: str
 
 
@@ -48,7 +48,7 @@ class HealthResponse(BaseModel):
 
     status: str
     model_loaded: bool
-    model_version: str | None
+    model_version: int | None
 
 
 class ModelInfoResponse(BaseModel):
@@ -56,5 +56,5 @@ class ModelInfoResponse(BaseModel):
 
     model_name: str
     model_alias: str
-    model_version: str | None
+    model_version: int | None
     run_id: str | None

--- a/src/serving/schemas.py
+++ b/src/serving/schemas.py
@@ -1,0 +1,60 @@
+"""Pydantic v2 schemas for all API request and response types.
+
+No raw dicts cross the API boundary — every endpoint uses one of these
+models for both request parsing and response serialisation.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class HDBFeatureInput(BaseModel):
+    """Feature fields shared by prediction and explanation requests.
+
+    The serving layer derives flat_info and float_time_series from the natural
+    fields supplied here, matching the preprocessing applied during training.
+    """
+
+    town: str = Field(..., examples=["ANG MO KIO"])
+    flat_type: str = Field(..., examples=["3 ROOM"])
+    flat_model: str = Field(..., examples=["Model A"])
+    storey_range: str = Field(..., examples=["07 TO 09"])
+    floor_area_sqm: float = Field(..., gt=0, examples=[67.0])
+    lease_commence_date: int = Field(..., gt=1960, lt=2030, examples=[1986])
+    month: str = Field(..., pattern=r"^\d{4}-\d{2}$", examples=["2024-01"])
+
+
+class PredictRequest(HDBFeatureInput):
+    """Input features for a single resale price prediction."""
+
+
+class PredictResponse(BaseModel):
+    """Prediction result with model provenance."""
+
+    predicted_resale_price: float
+    model_version: str
+    model_alias: str
+
+
+class ExplainRequest(HDBFeatureInput):
+    """Input features for a SHAP explanation request.
+
+    Schema matches PredictRequest; kept as a separate type so the response
+    contract can evolve independently when SHAP is wired in.
+    """
+
+
+class HealthResponse(BaseModel):
+    """Service health and model load status."""
+
+    status: str
+    model_loaded: bool
+    model_version: str | None
+
+
+class ModelInfoResponse(BaseModel):
+    """Metadata about the currently loaded model version."""
+
+    model_name: str
+    model_alias: str
+    model_version: str | None
+    run_id: str | None


### PR DESCRIPTION
Phase 1 task 2: FastAPI serving layer over the registered hdb-predictor model.

## What this adds

- Endpoints: `POST /predict`, `POST /explain` (501 stub), `GET /health`, `GET /model-info`
- Pydantic v2 schemas in `src/serving/schemas.py` — no raw dicts at the API boundary
- ModelLoader in `src/serving/model_loader.py` — loads from `models:/hdb-predictor@champion` at startup, polls every 60s, atomically swaps the in-memory model when alias points to a new version
- Configuration via Pydantic Settings (MLFLOW_TRACKING_URI, MODEL_NAME, MODEL_ALIAS, RELOAD_INTERVAL_SECONDS)
- Logging configured inside FastAPI lifespan startup

## What this defers

- Tests for the serving layer — separate task next
- SHAP `/explain` implementation — `/explain` returns 501 with a JSON body indicating SHAP is pending
- Streamlit refactor as thin HTTP client — separate task

## Verified end-to-end

- `/health` returns 200 with model_loaded=true, model_version=1
- `/model-info` resolves the alias chain back to source run b90b186
- `/predict` for a 1985 Tampines 4-room, 95sqm, mid-floor, June 2024 returns SGD 607,471 — within realistic resale range
- `/explain` returns 501 with the SHAP-pending JSON body

## Known issues tracked separately

- #3: training script does not auto-set @champion alias
- #9: training-serving feature pipeline duplication
- #10: model serving environment versions don't match training environment