### PR TITLE
feat(serving): SHAP TreeExplainer integration for /explain endpoint

### DIFF
--- a/src/serving/app.py
+++ b/src/serving/app.py
@@ -3,7 +3,7 @@
 Endpoints
 ---------
 POST /predict       — single-flat resale price prediction
-POST /explain       — SHAP feature contributions (stub, returns 501)
+POST /explain       — SHAP feature contributions (TreeExplainer)
 GET  /health        — service liveness and model load status
 GET  /model-info    — metadata for the currently loaded model version
 """
@@ -12,15 +12,16 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import numpy as np
 import pandas as pd
 from fastapi import FastAPI, HTTPException, status
-from fastapi.responses import JSONResponse
 
 from serving.config import ServingConfig
 from serving.logging_config import configure_logging
 from serving.model_loader import ModelLoader
 from serving.schemas import (
     ExplainRequest,
+    ExplainResponse,
     HDBFeatureInput,
     HealthResponse,
     ModelInfoResponse,
@@ -107,23 +108,62 @@ async def predict(req: PredictRequest) -> PredictResponse:
     )
 
 
-@app.post("/explain")
-async def explain(req: ExplainRequest) -> JSONResponse:
+@app.post("/explain", response_model=ExplainResponse)
+async def explain(req: ExplainRequest) -> ExplainResponse:
     """Return SHAP feature contributions for a single prediction.
 
-    SHAP TreeExplainer integration is pending. The request schema is validated
-    now so the contract is established; the response body will be replaced with
-    per-feature contributions in the next serving task.
+    Uses a TreeExplainer initialised at model load time — not per request.
+    The explainer operates on post-preprocessing features, so feature_contributions
+    keys are the transformed column names from the sklearn ColumnTransformer.
+
+    By construction: sum(feature_contributions.values()) + base_value ≈ predicted_resale_price.
     """
-    return JSONResponse(
-        status_code=501,
-        content={
-            "detail": (
-                "SHAP explainability is not yet implemented. "
-                "TreeExplainer integration is tracked as a separate task and "
-                "will replace this stub in the next iteration."
-            )
-        },
+    version = loader.get_version()
+    if version is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Model not loaded yet — try again shortly",
+        )
+    shap_bundle = loader.get_explainer()
+    if shap_bundle is None:
+        logger.error("SHAP explainer unavailable despite model being loaded (version %s)", version)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="SHAP explainer not available — try again shortly",
+        )
+    model = loader.get_model()
+    df = _build_feature_dataframe(req)
+    try:
+        prediction = float(model.predict(df)[0])  # type: ignore[index]
+        X_transformed = shap_bundle.preprocessor.transform(df)  # type: ignore[attr-defined]
+        shap_values = shap_bundle.explainer.shap_values(X_transformed)
+        # expected_value is a scalar for some tree models but a 1-element array for
+        # GradientBoostingRegressor — .item() handles both safely.
+        base_value = float(np.asarray(shap_bundle.explainer.expected_value).item())
+        contributions: dict[str, float] = dict(
+            zip(shap_bundle.feature_names, shap_values[0].tolist(), strict=False)
+        )
+    except Exception as exc:
+        logger.exception("SHAP explanation failed for request: %s", req.model_dump())
+        raise HTTPException(status_code=500, detail="Explanation failed.") from exc
+
+    top_contributor = max(contributions, key=lambda k: abs(contributions[k]))
+    logger.info(
+        "explain request: town=%s flat_type=%s floor_area_sqm=%.1f, "
+        "prediction=%.2f, top_contributor=%s",
+        req.town,
+        req.flat_type,
+        req.floor_area_sqm,
+        prediction,
+        top_contributor,
+    )
+
+    return ExplainResponse(
+        predicted_resale_price=round(prediction, 2),
+        base_value=base_value,
+        feature_contributions=contributions,
+        model_version=version,
+        model_alias=config.model_alias,
     )
 
 

--- a/src/serving/model_loader.py
+++ b/src/serving/model_loader.py
@@ -6,14 +6,21 @@ checks the registry every RELOAD_INTERVAL_SECONDS. When the @champion alias
 points to a new version, the daemon loads it and swaps the in-memory reference
 under a threading.Lock. In-flight predictions hold a reference to the old model
 object and complete safely; the old object is GC'd once no references remain.
+
+The SHAP TreeExplainer is initialised alongside the model and stored in an
+ExplainerBundle. If explainer initialisation fails during a background reload,
+the existing model+explainer pair is retained rather than leaving the loader
+in an inconsistent state.
 """
 
 import logging
 import threading
 import time
+from dataclasses import dataclass
 
 import mlflow
 import mlflow.pyfunc
+import shap
 from mlflow import MlflowClient
 from mlflow.pyfunc import PyFuncModel
 
@@ -22,14 +29,27 @@ from serving.config import ServingConfig
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class ExplainerBundle:
+    """SHAP TreeExplainer paired with the preprocessing artifacts needed at request time.
+
+    Stored together so that the preprocessor and explainer are always consistent
+    with each other — both are derived from the same loaded model version.
+    """
+
+    explainer: shap.TreeExplainer
+    preprocessor: object  # sklearn ColumnTransformer; typed as object to avoid hard sklearn import
+    feature_names: list[str]
+
+
 class ModelLoader:
     """Loads the champion model from MLflow registry and polls for version changes.
 
-    Thread safety: _model and _current_version are only mutated inside
-    self._lock. The model load itself happens outside the lock — loading is
-    slow and blocking predictions during it would be unacceptable. Python's
-    reference counting guarantees the old model stays alive until all
-    in-flight predictions that hold a reference to it finish.
+    Thread safety: _model, _current_version, and _explainer are only mutated
+    inside self._lock. Model and explainer loading happen outside the lock —
+    both are slow and blocking predictions during them would be unacceptable.
+    The explainer and model are always swapped together; a failed explainer
+    init prevents the model swap so the pair stays consistent.
     """
 
     def __init__(self, config: ServingConfig) -> None:
@@ -37,17 +57,19 @@ class ModelLoader:
         self._lock = threading.Lock()
         self._model: PyFuncModel | None = None
         self._current_version: int | None = None
+        self._explainer: ExplainerBundle | None = None
         mlflow.set_tracking_uri(config.mlflow_tracking_uri)
         self._client = MlflowClient()
 
     def load_initial(self) -> None:
-        """Synchronously load the champion model at application startup.
+        """Synchronously load the champion model and explainer at application startup.
 
         Intentionally raises on failure so the app fails fast rather than
         starting in a state where /predict immediately returns 500.
 
         Raises:
-            Exception: Any MLflow error from alias resolution or model download.
+            Exception: Any MLflow error from alias resolution, model download,
+                       or SHAP TreeExplainer initialisation.
         """
         logger.info(
             "Loading %s@%s from %s",
@@ -58,13 +80,16 @@ class ModelLoader:
         version = self._resolve_alias_version()
         model_uri = f"models:/{self._config.model_name}@{self._config.model_alias}"
         model = mlflow.pyfunc.load_model(model_uri)
+        bundle = self._build_explainer_bundle(model)
         with self._lock:
             self._model = model
             self._current_version = version
+            self._explainer = bundle
         logger.info(
-            "Loaded %s version %s",
+            "Loaded %s version %s with SHAP TreeExplainer (%d features)",
             self._config.model_name,
             version,
+            len(bundle.feature_names),
         )
 
     def get_model(self) -> PyFuncModel:
@@ -85,6 +110,11 @@ class ModelLoader:
         """Return the version string of the currently loaded model."""
         with self._lock:
             return self._current_version
+
+    def get_explainer(self) -> ExplainerBundle | None:
+        """Return the SHAP ExplainerBundle for the currently loaded model version."""
+        with self._lock:
+            return self._explainer
 
     def get_run_id(self) -> str | None:
         """Return the MLflow run ID associated with the currently loaded version.
@@ -117,6 +147,28 @@ class ModelLoader:
             self._config.reload_interval_seconds,
         )
 
+    def _build_explainer_bundle(self, model: PyFuncModel) -> ExplainerBundle:
+        """Initialise a TreeExplainer from the sklearn pipeline inside the pyfunc model.
+
+        Extracts the fitted preprocessor and the GradientBoostingRegressor from
+        the pipeline, then wraps them into an ExplainerBundle alongside the
+        post-transformation feature names.
+
+        Raises:
+            Exception: If the model is not a sklearn pipeline with the expected
+                       named steps, or if shap.TreeExplainer raises.
+        """
+        sklearn_pipeline = model._model_impl.sklearn_model  # type: ignore[attr-defined]
+        preprocessor = sklearn_pipeline.named_steps["preprocessor"]
+        regressor = sklearn_pipeline.named_steps["regressor"]
+        feature_names = list(preprocessor.get_feature_names_out())
+        explainer = shap.TreeExplainer(regressor)
+        return ExplainerBundle(
+            explainer=explainer,
+            preprocessor=preprocessor,
+            feature_names=feature_names,
+        )
+
     def _resolve_alias_version(self) -> int:
         """Return the model version currently pointed to by the configured alias."""
         mv = self._client.get_model_version_by_alias(
@@ -125,7 +177,12 @@ class ModelLoader:
         return mv.version
 
     def _reload_if_changed(self) -> None:
-        """Check the registry and swap the in-memory model if the alias moved."""
+        """Check the registry and swap the in-memory model+explainer if the alias moved.
+
+        If explainer initialisation fails for a new version, the existing
+        model+explainer pair is retained and the error is logged. This avoids
+        leaving the loader in a state where model and explainer are mismatched.
+        """
         try:
             latest_version = self._resolve_alias_version()
             with self._lock:
@@ -140,11 +197,23 @@ class ModelLoader:
             )
             model_uri = f"models:/{self._config.model_name}@{self._config.model_alias}"
             new_model = mlflow.pyfunc.load_model(model_uri)
+
+            try:
+                new_bundle = self._build_explainer_bundle(new_model)
+            except Exception:
+                logger.exception(
+                    "Explainer initialisation failed for version %s; "
+                    "retaining current model+explainer",
+                    latest_version,
+                )
+                return
+
             with self._lock:
                 self._model = new_model
                 self._current_version = latest_version
+                self._explainer = new_bundle
             logger.info(
-                "Model swapped: %s now at version %s",
+                "Model and explainer swapped: %s now at version %s",
                 self._config.model_name,
                 latest_version,
             )

--- a/src/serving/schemas.py
+++ b/src/serving/schemas.py
@@ -39,8 +39,22 @@ class ExplainRequest(HDBFeatureInput):
     """Input features for a SHAP explanation request.
 
     Schema matches PredictRequest; kept as a separate type so the response
-    contract can evolve independently when SHAP is wired in.
+    contract can evolve independently.
     """
+
+
+class ExplainResponse(BaseModel):
+    """SHAP explanation result with per-feature contributions and model provenance.
+
+    The additivity property holds by construction for tree models:
+    sum(feature_contributions.values()) + base_value ≈ predicted_resale_price.
+    """
+
+    predicted_resale_price: float
+    base_value: float
+    feature_contributions: dict[str, float]
+    model_version: int
+    model_alias: str
 
 
 class HealthResponse(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,13 @@ import mlflow.sklearn
 import numpy as np
 import pandas as pd
 import pytest
+import shap
 from sklearn.compose import ColumnTransformer
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder
+
+from serving.model_loader import ExplainerBundle
 
 _NUMERIC_FEATURES = ["floor_area_sqm", "lease_commence_date", "float_time_series"]
 _CATEGORICAL_FEATURES = ["town", "storey_range", "flat_info"]
@@ -83,13 +86,37 @@ def register_model_version(
     return info.registered_model_version
 
 
+def build_fixture_explainer_bundle(pipeline: Pipeline) -> ExplainerBundle:
+    """Build an ExplainerBundle from a fitted fixture pipeline.
+
+    Used in app tests that need a real SHAP explainer without an MLflow roundtrip.
+    """
+    preprocessor = pipeline.named_steps["preprocessor"]
+    regressor = pipeline.named_steps["regressor"]
+    feature_names = list(preprocessor.get_feature_names_out())
+    explainer = shap.TreeExplainer(regressor)
+    return ExplainerBundle(
+        explainer=explainer,
+        preprocessor=preprocessor,
+        feature_names=feature_names,
+    )
+
+
 class StubModelLoader:
     """Test double for ModelLoader. No MLflow calls; state is set at construction."""
 
-    def __init__(self, *, model=None, version=None, run_id: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        model=None,
+        version=None,
+        run_id: str | None = None,
+        explainer: ExplainerBundle | None = None,
+    ) -> None:
         self._model = model
         self._version = version
         self._run_id = run_id
+        self._explainer = explainer
 
     def load_initial(self) -> None:
         pass
@@ -107,6 +134,9 @@ class StubModelLoader:
 
     def get_run_id(self) -> str | None:
         return self._run_id
+
+    def get_explainer(self) -> ExplainerBundle | None:
+        return self._explainer
 
 
 @pytest.fixture

--- a/tests/serving/test_app.py
+++ b/tests/serving/test_app.py
@@ -13,7 +13,12 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 import serving.app as app_module
-from tests.conftest import StubModelLoader
+from tests.conftest import (
+    StubModelLoader,
+    build_fixture_explainer_bundle,
+    build_fixture_pipeline,
+    make_synthetic_features,
+)
 
 _TAMPINES_4ROOM = {
     "town": "TAMPINES",
@@ -159,17 +164,81 @@ class TestPredictEndpoint:
         assert isinstance(resp.json()["model_version"], int)
 
 
+@pytest.fixture
+def _fitted_pipeline():
+    """A fitted sklearn pipeline for SHAP tests — built once, shared within the module."""
+    X, y = make_synthetic_features(n=120)
+    pipeline = build_fixture_pipeline()
+    pipeline.fit(X, y)
+    return pipeline
+
+
+@pytest.fixture
+async def explain_client(monkeypatch, _fitted_pipeline):
+    """AsyncClient backed by a real sklearn pipeline and SHAP bundle.
+
+    Both the model and the explainer are derived from the same fitted pipeline
+    so the SHAP additivity property holds — predicted_resale_price from
+    model.predict equals base_value + sum(feature_contributions).
+    """
+    bundle = build_fixture_explainer_bundle(_fitted_pipeline)
+    stub = StubModelLoader(
+        model=_fitted_pipeline,
+        version="42",
+        run_id="test-run-shap",
+        explainer=bundle,
+    )
+    monkeypatch.setattr(app_module, "loader", stub)
+    async with AsyncClient(
+        transport=ASGITransport(app=app_module.app), base_url="http://test"
+    ) as client:
+        yield client
+
+
 class TestExplainEndpoint:
-    async def test_explain_returns_501(self, loaded_client):
-        resp = await loaded_client.post("/explain", json=_TAMPINES_4ROOM)
-        assert resp.status_code == 501
+    async def test_explain_happy_path_tampines_4room_returns_200(self, explain_client):
+        resp = await explain_client.post("/explain", json=_TAMPINES_4ROOM)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "predicted_resale_price" in body
+        assert "base_value" in body
+        assert "feature_contributions" in body
+        assert "model_version" in body
+        assert "model_alias" in body
+        assert isinstance(body["feature_contributions"], dict)
+        assert len(body["feature_contributions"]) > 0
+        assert 100_000 < body["predicted_resale_price"] < 2_000_000
 
-    async def test_explain_501_body_mentions_shap(self, loaded_client):
-        resp = await loaded_client.post("/explain", json=_TAMPINES_4ROOM)
-        assert "SHAP" in resp.json()["detail"]
+    async def test_explain_all_response_fields_are_populated(self, explain_client):
+        resp = await explain_client.post("/explain", json=_TAMPINES_4ROOM)
+        body = resp.json()
+        assert body["model_version"] == 42
+        assert body["model_alias"] == "champion"
+        assert isinstance(body["base_value"], float)
+        assert all(isinstance(v, float) for v in body["feature_contributions"].values())
 
-    async def test_explain_validates_request_schema(self, loaded_client):
-        # Validation runs before the stub response, so malformed input still 422s
+    async def test_explain_additivity_holds_within_epsilon(self, explain_client):
+        """sum(contributions) + base_value ≈ predicted_resale_price within 1.0 SGD."""
+        resp = await explain_client.post("/explain", json=_TAMPINES_4ROOM)
+        body = resp.json()
+        shap_total = sum(body["feature_contributions"].values()) + body["base_value"]
+        assert abs(shap_total - body["predicted_resale_price"]) < 1.0
+
+    async def test_explain_returns_503_when_version_not_loaded(self, version_unknown_client):
+        resp = await version_unknown_client.post("/explain", json=_TAMPINES_4ROOM)
+        assert resp.status_code == 503
+
+    async def test_explain_returns_422_on_negative_floor_area(self, explain_client):
         payload = {**_TAMPINES_4ROOM, "floor_area_sqm": -1.0}
-        resp = await loaded_client.post("/explain", json=payload)
+        resp = await explain_client.post("/explain", json=payload)
+        assert resp.status_code == 422
+
+    async def test_explain_returns_422_on_bad_month_format(self, explain_client):
+        payload = {**_TAMPINES_4ROOM, "month": "2024-6"}
+        resp = await explain_client.post("/explain", json=payload)
+        assert resp.status_code == 422
+
+    async def test_explain_returns_422_on_invalid_lease_year(self, explain_client):
+        payload = {**_TAMPINES_4ROOM, "lease_commence_date": 1959}
+        resp = await explain_client.post("/explain", json=payload)
         assert resp.status_code == 422

--- a/tests/serving/test_model_loader.py
+++ b/tests/serving/test_model_loader.py
@@ -159,3 +159,68 @@ class TestErrorResilience:
 
         assert loader.get_version() == version_before
         assert loader.get_model() is model_before
+
+    def test_reload_retains_model_when_explainer_init_fails(self, two_version_setup, monkeypatch):
+        uri, v1, v2 = two_version_setup
+        loader = ModelLoader(_make_config(uri))
+        loader.load_initial()
+
+        bundle_before = loader.get_explainer()
+        version_before = loader.get_version()
+
+        def _explainer_fails(model):
+            raise RuntimeError("Simulated explainer failure")
+
+        monkeypatch.setattr(loader, "_build_explainer_bundle", _explainer_fails)
+
+        # Move alias to v2 — reload will load the new model but explainer init fails
+        client = MlflowClient()
+        client.set_registered_model_alias("hdb-predictor", "champion", v2)
+        loader._reload_if_changed()
+
+        # Model and explainer should be unchanged — pair consistency preserved
+        assert loader.get_version() == version_before
+        assert loader.get_explainer() is bundle_before
+
+
+class TestExplainerBundle:
+    def test_get_explainer_returns_none_before_load(self, isolated_mlflow_uri):
+        loader = ModelLoader(_make_config(isolated_mlflow_uri))
+        assert loader.get_explainer() is None
+
+    def test_get_explainer_returns_bundle_after_load(self, single_version_setup):
+        uri, _ = single_version_setup
+        loader = ModelLoader(_make_config(uri))
+        loader.load_initial()
+
+        bundle = loader.get_explainer()
+        assert bundle is not None
+        assert bundle.explainer is not None
+        assert len(bundle.feature_names) > 0
+
+    def test_explainer_feature_names_match_preprocessor_output(self, single_version_setup):
+        uri, _ = single_version_setup
+        loader = ModelLoader(_make_config(uri))
+        loader.load_initial()
+
+        bundle = loader.get_explainer()
+        assert bundle is not None
+        expected_names = list(bundle.preprocessor.get_feature_names_out())
+        assert bundle.feature_names == expected_names
+
+    def test_explainer_swaps_atomically_with_model_on_alias_change(self, two_version_setup):
+        uri, v1, v2 = two_version_setup
+        loader = ModelLoader(_make_config(uri))
+        loader.load_initial()
+
+        bundle_v1 = loader.get_explainer()
+        assert bundle_v1 is not None
+
+        client = MlflowClient()
+        client.set_registered_model_alias("hdb-predictor", "champion", v2)
+        loader._reload_if_changed()
+
+        bundle_v2 = loader.get_explainer()
+        assert bundle_v2 is not None
+        assert bundle_v2 is not bundle_v1
+        assert int(loader.get_version()) == int(v2)


### PR DESCRIPTION
Phase 1 task 4: replace the /explain 501 stub with a working SHAP TreeExplainer integration.

## What this adds

- New `ExplainResponse` schema: `predicted_resale_price`, `base_value`, `feature_contributions: dict[str, float]`, `model_version`, `model_alias`
- `ExplainerBundle` dataclass on the ModelLoader: TreeExplainer + preprocessor + feature_names. Swapped atomically alongside the model inside the same lock acquisition — model and explainer cannot drift out of sync
- `/explain` endpoint: version guard → bundle guard → predict → preprocess → SHAP values → dict zip
- 9 new tests (66 total): TestExplainerBundle (4), TestErrorResilience explainer-failure pair test (1), TestExplainEndpoint (7) including the SHAP additivity assertion

## Design decisions

- **Atomic swap unit.** Bundling explainer + preprocessor + feature_names rather than individual attributes makes 'model and explainer must always be consistent' a structural invariant rather than a documented convention.
- **Failed explainer init aborts the swap.** If SHAP cannot initialise on a new model version, the loader keeps the previous (working) pair rather than ending up half-updated.
- **Real fitted pipeline in test fixture.** The `explain_client` fixture uses an actual sklearn pipeline so the additivity assertion is meaningful — `sum(contributions) + base_value ≈ prediction` only holds for a real model that SHAP can decompose.
- **expected_value extraction.** GradientBoostingRegressor returns expected_value as a 1-element numpy array, not a scalar. Handled with `np.asarray(...).item()`.

## Verified end-to-end

- /explain happy path returns 200 with all fields populated
- SHAP additivity asserted: sum(contributions) + base_value within 1.0 SGD of prediction
- /explain returns 503 when no model loaded (mirrors /predict 503 path)
- /explain returns 422 on schema validation errors

## Out of scope

- Streamlit waterfall visualisation (next task)
- Top-N feature filtering (return all contributions; Streamlit handles presentation)
- Caching of repeated identical explain requests

## Known issues tracked separately

- #9: training-serving feature pipeline duplication (the explain handler perpetuates this; not fixed here)