### PR TITLE
chore(ui): preserve legacy chat app as reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-extend-exclude = ["**/legacy_*.py"]
+extend-exclude = ["**/legacy_*.py", "src/ui/legacy_chat_app/**"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "SIM", "RUF"]
@@ -39,7 +39,7 @@ ignore = [
 
 [tool.ruff.format]
 quote-style = "double"
-exclude = ["**/legacy_*.py"]
+exclude = ["**/legacy_*.py", "src/ui/legacy_chat_app/**"]
 
 [tool.mypy]
 python_version = "3.12"
@@ -48,7 +48,7 @@ explicit_package_bases = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
-exclude = ["legacy_.*\\.py$"]
+exclude = ["legacy_.*\\.py$", "src/ui/legacy_chat_app/.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ui/legacy_chat_app/README.md
+++ b/src/ui/legacy_chat_app/README.md
@@ -1,0 +1,25 @@
+# Legacy Chat App (Reference Only)
+
+This is the original Streamlit chat application from the pre-MLOps version of the HDB resale price predictor. **It is preserved here as reference material.** It is not run, tested, or deployed by the current platform.
+
+## What it was
+
+A Streamlit chat UI where users described a flat in plain English (e.g. "4-room in Tampines, 90 sqm, postal 520329, lease started 1992") and Claude Haiku extracted the required fields via tool use, then called a local XGBoost model.
+
+## Why it's here, not used
+
+Three mismatches with the current platform:
+
+1. **Different model.** Used XGBoost; the current pipeline uses GradientBoostingRegressor.
+2. **Different feature schema.** Used `floor_area`, `lease_commence_date`, `postal_code`, `town`, `flat_type` (5 fields). The current `HDBFeatureInput` schema has 7 fields including `flat_model`, `storey_range`, `month`, and no `postal_code`.
+3. **Architectural mismatch.** Loaded a pickle directly via `joblib.load`. The current platform requires UI to call FastAPI `/predict` and `/explain` over HTTP.
+
+## What's missing
+
+The `models/XBR_trained_hdb_resale_modelV4a.pkl` file is not committed — it's not needed as reference. The chat app would not run from this directory anyway.
+
+## Future plan
+
+Once the platform is past Phase 2 (Docker + CI), this chat agent will be retrofitted to call `/predict` and `/explain` over HTTP, with the tool-use schema updated to match `HDBFeatureInput`. The chat then becomes a sibling app to the form-based `src/ui/streamlit_app.py`, demonstrating two ergonomic input modes against the same MLOps backend.
+
+Tracked in a follow-up issue.

--- a/src/ui/legacy_chat_app/chat_agent.py
+++ b/src/ui/legacy_chat_app/chat_agent.py
@@ -1,0 +1,132 @@
+# mypy: ignore-errors
+# ruff: noqa
+"""Claude tool-use loop for extracting HDB flat features from natural language
+and calling the local predictor. The LLM never sees the model — it only handles
+slot-filling, follow-up questions, and response framing."""
+
+from anthropic import Anthropic
+
+from predictor import FLAT_TYPES, TOWNS, predict_price
+
+MODEL = "claude-haiku-4-5-20251001"
+
+_client = Anthropic()
+
+TOOLS = [
+    {
+        "name": "predict_hdb_price",
+        "description": (
+            "Predict the resale price of a Singapore HDB flat. Only call this "
+            "once all five fields are known with confidence. If any field is "
+            "missing or ambiguous, ask the user a concise follow-up question "
+            "instead of calling this tool."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "floor_area": {
+                    "type": "number",
+                    "description": "Floor area in square meters (sqm).",
+                },
+                "lease_commence_date": {
+                    "type": "integer",
+                    "description": "Year the lease began, between 1960 and the current year.",
+                },
+                "postal_code": {
+                    "type": "integer",
+                    "description": "6-digit Singapore postal code.",
+                },
+                "town": {
+                    "type": "string",
+                    "enum": TOWNS,
+                    "description": "HDB town name (uppercase).",
+                },
+                "flat_type": {
+                    "type": "string",
+                    "enum": FLAT_TYPES,
+                    "description": "HDB flat type.",
+                },
+            },
+            "required": [
+                "floor_area",
+                "lease_commence_date",
+                "postal_code",
+                "town",
+                "flat_type",
+            ],
+        },
+    }
+]
+
+SYSTEM_PROMPT = (
+    "You are an assistant that estimates Singapore HDB resale prices. "
+    "Users describe a flat in plain English; your job is to extract the five "
+    "required fields (floor_area in sqm, lease_commence_date as a year, "
+    "postal_code, town, flat_type) and call the predict_hdb_price tool.\n\n"
+    "Rules:\n"
+    "- If any field is missing or ambiguous, ask ONE concise follow-up question "
+    "and do not call the tool yet.\n"
+    "- Normalize town and flat_type to the allowed enum values (uppercase).\n"
+    "- Politely decline requests about non-HDB properties (condos, landed, "
+    "commercial) — this model only covers HDB resale flats.\n"
+    "- When you get a tool result, present the price in Singapore dollars and "
+    "briefly restate the flat the estimate is for. Remind the user the figure "
+    "is an estimate."
+)
+
+
+def chat_turn(history: list) -> tuple[list, str]:
+    """Run one user turn. `history` is the running Anthropic messages list and
+    is mutated in place. Returns (history, assistant_text_for_display)."""
+    while True:
+        resp = _client.messages.create(
+            model=MODEL,
+            max_tokens=1024,
+            system=[
+                {
+                    "type": "text",
+                    "text": SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            tools=TOOLS,
+            messages=history,
+        )
+
+        history.append({"role": "assistant", "content": resp.content})
+
+        if resp.stop_reason == "tool_use":
+            tool_use = next(b for b in resp.content if b.type == "tool_use")
+            try:
+                price = predict_price(**tool_use.input)
+                result_text = f"predicted_price_sgd={price}"
+                is_error = False
+            except Exception as e:
+                import traceback
+                tb = traceback.format_exc()
+                print(f"[chat_agent] predict_price failed:\n{tb}", flush=True)
+                result_text = (
+                    f"error: {type(e).__name__}: {e}. "
+                    "Report this exact error message to the user verbatim "
+                    "so they can debug — do NOT say the system is temporarily "
+                    "unavailable or ask them to retry."
+                )
+                is_error = True
+
+            history.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_use.id,
+                            "content": result_text,
+                            "is_error": is_error,
+                        }
+                    ],
+                }
+            )
+            continue
+
+        text = "".join(b.text for b in resp.content if b.type == "text")
+        return history, text

--- a/src/ui/legacy_chat_app/predictor.py
+++ b/src/ui/legacy_chat_app/predictor.py
@@ -1,0 +1,69 @@
+# mypy: ignore-errors
+# ruff: noqa
+"""Pure prediction layer — no Streamlit, no LLM. Loads the trained XGBoost
+model once at import and exposes predict_price() as a plain function."""
+
+import os
+from datetime import date
+
+import joblib
+
+TOWNS = [
+    "ANG MO KIO", "BEDOK", "BISHAN", "BUKIT BATOK", "BUKIT MERAH",
+    "BUKIT PANJANG", "BUKIT TIMAH", "CENTRAL AREA", "CHOA CHU KANG",
+    "CLEMENTI", "GEYLANG", "HOUGANG", "JURONG EAST", "JURONG WEST",
+    "KALLANG/WHAMPOA", "MARINE PARADE", "PASIR RIS", "PUNGGOL",
+    "QUEENSTOWN", "SEMBAWANG", "SENGKANG", "SERANGOON", "TAMPINES",
+    "TOA PAYOH", "WOODLANDS", "YISHUN",
+]
+
+FLAT_TYPES = [
+    "3 ROOM", "4 ROOM", "5 ROOM", "EXECUTIVE", "MULTI-GENERATION",
+]
+
+_MODEL_PATH = os.path.join(
+    os.path.dirname(__file__), "models", "XBR_trained_hdb_resale_modelV4a.pkl"
+)
+
+_model = None
+
+
+def _get_model():
+    global _model
+    if _model is None:
+        _model = joblib.load(_MODEL_PATH)
+    return _model
+
+
+def predict_price(
+    *,
+    floor_area: float,
+    lease_commence_date: int,
+    postal_code: int,
+    town: str,
+    flat_type: str,
+    current_year: int | None = None,
+) -> int:
+    """Predict HDB resale price. Returns price rounded to nearest $1,000.
+
+    Raises ValueError on unknown town or flat_type.
+    """
+    if current_year is None:
+        current_year = date.today().year
+
+    town = town.upper().strip()
+    flat_type = flat_type.upper().strip()
+
+    if town not in TOWNS:
+        raise ValueError(f"Unknown town: {town!r}. Must be one of {TOWNS}.")
+    if flat_type not in FLAT_TYPES:
+        raise ValueError(
+            f"Unknown flat type: {flat_type!r}. Must be one of {FLAT_TYPES}."
+        )
+
+    features = [floor_area, lease_commence_date, postal_code, current_year]
+    features += [1 if t == town else 0 for t in TOWNS]
+    features += [1 if f == flat_type else 0 for f in FLAT_TYPES]
+
+    price = float(_get_model().predict([features])[0])
+    return int(round(price / 1000) * 1000)

--- a/src/ui/legacy_chat_app/requirements.txt
+++ b/src/ui/legacy_chat_app/requirements.txt
@@ -1,0 +1,7 @@
+streamlit>=1.31.0
+pandas>=2.1.4
+joblib>=1.3.2
+numpy>=1.26.3
+xgboost>=2.0.3
+scikit-learn>=1.4.0
+anthropic>=0.40.0

--- a/src/ui/legacy_chat_app/streamlit_app.py
+++ b/src/ui/legacy_chat_app/streamlit_app.py
@@ -1,0 +1,65 @@
+# mypy: ignore-errors
+# ruff: noqa
+"""Streamlit chat UI for the HDB resale price predictor.
+
+Users describe a flat in natural language; Claude (Haiku) extracts the five
+required fields via tool use and calls the local XGBoost model through
+predictor.predict_price().
+"""
+
+import streamlit as st
+
+from chat_agent import chat_turn
+
+st.set_page_config(
+    page_title="HDB Resale Price Chat",
+    page_icon="🏠",
+    layout="centered",
+)
+
+st.title("HDB Resale Price Chat")
+st.caption(
+    "Describe a flat in plain English — e.g. "
+    "*'4-room in Tampines, 90 sqm, postal 520329, lease started 1992'*"
+)
+
+# history: raw Anthropic-format messages (what we send to the API)
+# display: (role, text) tuples for rendering the conversation
+if "history" not in st.session_state:
+    st.session_state.history = []
+if "display" not in st.session_state:
+    st.session_state.display = []
+
+for role, text in st.session_state.display:
+    with st.chat_message(role):
+        st.markdown(text)
+
+if prompt := st.chat_input("Ask about an HDB flat..."):
+    st.session_state.display.append(("user", prompt))
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    st.session_state.history.append({"role": "user", "content": prompt})
+
+    with st.chat_message("assistant"):
+        with st.spinner("Thinking..."):
+            try:
+                st.session_state.history, reply = chat_turn(st.session_state.history)
+            except Exception as e:
+                reply = f"Sorry, something went wrong: `{e}`"
+        st.markdown(reply)
+
+    st.session_state.display.append(("assistant", reply))
+
+with st.sidebar:
+    st.subheader("About")
+    st.write(
+        "XGBoost regression model trained on HDB resale transactions.\n\n"
+        "- MAE: ~$15,749\n"
+        "- R²: 0.982\n\n"
+        "Predictions are estimates; actual prices may vary."
+    )
+    if st.button("Clear conversation"):
+        st.session_state.history = []
+        st.session_state.display = []
+        st.rerun()


### PR DESCRIPTION
The pre-MLOps Streamlit chat UI used Claude Haiku tool use against a
locally-loaded XGBoost pickle. The model, feature schema, and prediction
path all differ from the current MLOps platform. Preserve the four source
files at src/ui/legacy_chat_app/ as reference, alongside legacy_train.py.

Excluded from ruff and mypy via pyproject.toml and file-level markers.
The migration plan (chat agent over the new API) is tracked in #16.
