### PR TITLE
chore(tooling): commit Claude Code allow-list, ignore per-machine state

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(uv:*)",
+      "Bash(pip:*)",
+      "Bash(python:*)",
+      "Bash(pytest:*)",
+      "Bash(pre-commit:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(uvicorn:*)",
+      "Bash(streamlit:*)",
+      "Edit",
+      "Write",
+      "Read"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ mlflow.db-journal
 # Lookup tables are small and committed to the repo
 !/data/lookups/
 !/data/lookups/*
+
+# Claude Code per-machine state (settings.json is committed)
+.claude/*
+!.claude/settings.json

--- a/src/lookup/__init__.py
+++ b/src/lookup/__init__.py
@@ -3,4 +3,4 @@
 from lookup.abbreviations import expand_street_abbreviations
 from lookup.postal import AddressInfo, lookup_postal
 
-__all__ = ["AddressInfo", "lookup_postal", "expand_street_abbreviations"]
+__all__ = ["AddressInfo", "expand_street_abbreviations", "lookup_postal"]


### PR DESCRIPTION
- .claude/settings.json: allow-list for git, pytest, uv, pre-commit, and file
  edits. Speeds up Claude Code sessions by approving routine commands
  automatically while still prompting for unusual ones (rm, chmod, curl).
- .gitignore: ignore .claude/* except settings.json; remove redundant
  .claude/settings.local.json line now covered by the wildcard.
- src/lookup/__init__.py: alphabetical __all__ ordering (ruff auto-fix from
  an earlier session that wasn't committed).
