### PR TITLE
feat/phase1.6c langgraph orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A production-style MLOps platform for predicting Singapore HDB resale prices, with a chat-driven user interface on top. The model trains on 30+ years of public resale transaction data, serves predictions and SHAP-based explanations through a FastAPI service, and is wrapped by a Claude Haiku agent that turns plain-English property descriptions into structured predictions with natural-language explanations of what's driving the price.
 
-> **Status (June 2026)** — Phases 1, 1.5, 1.6a, and 1.6b are complete. Phase 1.6b added the MCP server: the platform's prediction, explanation, postal lookup, model-info, and comparable-search capabilities are now callable as Model Context Protocol tools from Claude Desktop or any other MCP client. LangGraph orchestration (Phase 1.6c) is next. See [What's next](#whats-next).
+> **Status (June 2026)** — Phases 1, 1.5, 1.6a, 1.6b, and 1.6c are complete. Phase 1.6b added the MCP server: prediction, explanation, postal lookup, model-info, and comparable-search are callable as Model Context Protocol tools from Claude Desktop or any other MCP client. Phase 1.6c replaced the chat agent's Anthropic tool-use loop with a LangGraph orchestration graph that calls those MCP tools as a deterministic state machine. See [What's next](#whats-next).
 
 ## What this demonstrates
 
@@ -14,8 +14,9 @@ The interesting parts of this repo, with specifics:
 - **Preprocessing baked into the sklearn `Pipeline`.** No training-serving feature pipeline duplication. The model artefact is end-to-end: raw input goes in, prediction comes out. A custom `MonthToFloatTransformer` converts `YYYY-MM` to fractional years inside the `ColumnTransformer`.
 - **Postal-code first chat UX.** Users type `"3 room flat in Tampines, 95 sqm, lease started 1985, postal 522201"` in plain English. The agent calls `lookup_postal_code` to resolve postal → town, then `predict_hdb_price` for the price, then `explain_hdb_price` and narrates the top 3 SHAP contributors back to the user in English.
 - **MCP server exposing the platform to any LLM client.** Five tools — `predict_price`, `explain_prediction`, `lookup_postal_code`, `get_model_info`, `find_similar_transactions` — are served over the Model Context Protocol, so Claude Desktop or Cursor call the same prediction and explanation logic the Streamlit chat uses, with no per-client code. The server calls the platform's Python modules directly rather than HTTP-wrapping FastAPI: one process, shared in-memory model, no localhost dependency ([ADR 0003](docs/adr/0003-mcp-direct-imports-not-http.md)). `explain_prediction` returns SHAP contributions twice over — raw feature names for programmatic consumers and human-readable labels for the LLM client to present directly — so a narrated explanation never leaks `cat__town_TAMPINES`-style pipeline internals.
-- **171 tests** across schemas, model loader, FastAPI endpoints, MCP tools, training pipeline, postal lookup, predictor, and chat agent. Pre-commit hooks enforce ruff, ruff-format, mypy, and a typed exception hierarchy in the API client.
-- **Architecture Decision Records** under `docs/adr/` for choices that matter — alias-vs-stages, promotion threshold derivation, MLflow SPOF acknowledgement.
+- **LangGraph orchestration with a deliberate node per step.** The chat turn is an explicit state machine — `parse -> postal_lookup -> validate -> (predict -> explain) -> narrate` — not an LLM-driven tool-use loop. A conditional edge after `validate` routes missing-field, out-of-scope, and error states straight to `narrate`, skipping prediction. The orchestration layer (LangGraph) and the tool layer (the MCP server, called in-process) are separate concerns: the graph decides *what happens when*, the MCP tools *do the work*. The LLM is demoted to two bounded nodes — `parse` does JSON slot-filling, `narrate` phrases the result — both calling the Anthropic SDK directly, with per-node error handling so a tool fault is narrated gracefully rather than raised ([ADR 0004](docs/adr/0004-langgraph-orchestration-over-direct-tool-loop.md)).
+- **239 tests** across schemas, model loader, FastAPI endpoints, MCP tools, training pipeline, postal lookup, predictor, the chat agent, and the orchestration graph — nodes, branch routing, and an end-to-end traversal against the real MCP tools. Pre-commit hooks enforce ruff, ruff-format, mypy, and a typed exception hierarchy in the API client.
+- **Architecture Decision Records** under `docs/adr/` for choices that matter — alias-vs-stages, SQLite as a derived store, MCP direct imports over HTTP, and LangGraph orchestration over a direct tool loop.
 
 ## Architecture
 
@@ -177,7 +178,7 @@ data/
 └── lookups/         Postal code reference table (committed, 700KB)
 ```
 
-Coming in Phase 1.6: a LangGraph state machine inside `src/ui/chat_app/` (Phase 1.6c) that orchestrates the MCP tools.
+The LangGraph orchestration graph lives in `src/ui/chat_app/graph/` (Phase 1.6c): `state.py` holds the threaded `GraphState`, `nodes/` holds one module per step, and `graph_builder.py` wires them together.
 
 ## Design decisions
 
@@ -227,7 +228,7 @@ The [build plan](docs/build-plan.md) tracks delivery in phases. Phases 1 and 1.5
 
 - **Phase 1.6a — SQLite data layer** — Complete. `src/data/` wraps the CSV data in a queryable SQLite database. Training reads from `data/hdb.db` via `load_all_transactions()`. `find_similar()` is implemented and ready for the Phase 1.6b MCP tool.
 - **Phase 1.6b — MCP server** ([#22](https://github.com/LEMSingapore/hdb-mlops-platform/issues/22)). Complete. `predict_price`, `explain_prediction`, `lookup_postal_code`, `get_model_info`, and `find_similar_transactions` are exposed as MCP tools in `src/mcp_server/`, consumable from Claude Desktop and any other MCP client. The server calls the platform's modules directly rather than HTTP-wrapping FastAPI ([ADR 0003](docs/adr/0003-mcp-direct-imports-not-http.md)).
-- **Phase 1.6c — LangGraph orchestration**. Replace the chat agent's direct tool-use loop with a LangGraph state machine that calls MCP tools. Each node handles a distinct step (parse, lookup, validate, predict, explain, narrate) with retry and error handling. — Target: late May
+- **Phase 1.6c — LangGraph orchestration** ([ADR 0004](docs/adr/0004-langgraph-orchestration-over-direct-tool-loop.md)). Complete. The chat agent's direct tool-use loop is replaced by a LangGraph state machine — `parse -> postal_lookup -> validate -> (predict -> explain) -> narrate` — calling the MCP tools in-process. Each node handles a distinct step with its own error handling; a conditional edge after `validate` routes missing-field, out-of-scope, and error states straight to narration.
 - **Phase 1.6d — AIAP-format README**. Restructure the project documentation to align with AIAP's 8-section submission template, dual-purposing this work for the AI Apprenticeship Programme. — Target: mid-May
 - **Phase 2 — Docker + CI**. Containerise FastAPI, MCP server, and MLflow tracking. GitHub Actions for lint, type-check, test, and image build on every PR. — Target: June
 - **Phase 3 — DVC + Pandera + scheduled ingestion**. Version the training data, validate it, ingest fresh data.gov.sg releases monthly via scheduled CI. — Target: July

--- a/README.md
+++ b/README.md
@@ -204,21 +204,22 @@ Both trained on 975,942 transactions with identical hyperparameters (`learning_r
 
 ## What's tested
 
-171 tests, run with `pytest`:
+239 tests, run with `pytest`:
 
 | Module | Tests | What it covers |
 |---|---:|---|
 | `tests/data/test_connection.py` | 5 | Context manager lifecycle, row_factory, env-var override, missing-DB error |
 | `tests/data/test_queries.py` | 18 | load_all_transactions, count_transactions, find_similar and find_similar_with_fallback (exact, fallback, edge cases) |
-| `tests/mcp_server/` | 19 | Tool registration and input schemas, plus one happy path per tool (predict, explain top-5, postal lookup, model info, similar transactions) |
-| `tests/serving/test_schemas.py` | 17 | Pydantic boundary conditions, validation errors, coercion rules |
-| `tests/serving/test_model_loader.py` | 16 | Alias resolution, atomic swap, `ExplainerBundle` consistency on failure |
-| `tests/serving/test_app.py` | 22 | All four endpoints, 503 guard, 422 validation, SHAP additivity |
+| `tests/mcp_server/` | 40 | Tool registration and input schemas, plus happy paths per tool (predict, explain top-5, postal lookup, model info, similar transactions) |
+| `tests/serving/test_schemas.py` | 18 | Pydantic boundary conditions, validation errors, coercion rules |
+| `tests/serving/test_model_loader.py` | 17 | Alias resolution, atomic swap, `ExplainerBundle` consistency on failure |
+| `tests/serving/test_app.py` | 19 | All four endpoints, 503 guard, 422 validation, SHAP additivity |
 | `tests/training/test_train.py` | 12 | End-to-end training from SQLite fixture, signature attached, alias set |
-| `tests/lookup/test_postal.py` | 14 | Postal resolution, town derivation, edge cases |
+| `tests/lookup/test_postal.py` | 15 | Postal resolution, town derivation, edge cases |
 | `tests/lookup/test_abbreviations.py` | 15 | Token-level expansion, idempotency, no substring collisions |
 | `tests/ui/form_app/` | 9 | API client error hierarchy, config from env |
-| `tests/ui/chat_app/` | 23 | Tool schemas, top-3 SHAP slice, missing-field elicitation, postal-first ordering |
+| `tests/ui/chat_app/` (agent + predictor) | 24 | Legacy tool-use loop schemas, top-3 SHAP slice, missing-field elicitation, postal-first ordering |
+| `tests/ui/chat_app/graph/` | 47 | GraphState, MCP client wrapper, the six nodes (parse and narrate with a mocked Anthropic client), branch routing, and end-to-end traversal against the real MCP tools |
 
 A lesson from this work: **passing tests don't mean the system works.** Pydantic v2 type bugs, environment-variable plumbing in subprocess models, and explainer initialisation paths all needed live smoke testing — three terminals, real curl, real chat — to catch issues that unit tests can't see.
 

--- a/docs/adr/0004-langgraph-orchestration-over-direct-tool-loop.md
+++ b/docs/adr/0004-langgraph-orchestration-over-direct-tool-loop.md
@@ -1,0 +1,38 @@
+# ADR 0004: LangGraph orchestration replaces the direct Anthropic tool-use loop
+
+**Status:** Accepted
+**Date:** 2026-06-12
+
+## Context
+
+The Phase 1.6 chat UI ran on a single Anthropic tool-use loop in `chat_agent.py`: one `messages.create` call with three tools attached, a `while` loop that dispatched whatever tool the model asked for, fed the result back, and repeated until the model stopped calling tools and produced prose. It worked, and for a three-tool flow it was about as small as orchestration gets. But the model owned the control flow. Whether the postal lookup ran, whether a prediction happened before an explanation, whether all five fields were actually present before predicting — all of that lived inside the model's reasoning, visible only as a sequence of tool calls after the fact. When something went wrong, the failure was a turn in a transcript, not a step I could point at.
+
+Phase 1.6b had already moved the actual capabilities — predict, explain, postal lookup — behind the MCP server, so the tool layer was settled. What was left was the orchestration: the deterministic shape of a turn. I wanted that shape to be code I could read, test branch by branch, and attach per-step error handling to, rather than an emergent property of an LLM's tool-calling. That is what Phase 1.6c set out to build.
+
+## Decision
+
+The chat turn is orchestrated by an explicit LangGraph state machine over a single `GraphState`, with the LLM demoted from controller to two bounded steps inside it. The graph is `parse -> postal_lookup -> validate -> (predict -> explain) -> narrate`, with a conditional edge after `validate` routing everything that is not `ready_to_predict` — missing fields, out of scope, or an upstream error — straight to `narrate`. Each node owns one step, returns a dict of the fields it changed, and carries its own error handling; a tool fault sets `status = "error"` on the state and the graph routes around the prediction nodes rather than raising.
+
+The two LLM-backed nodes call the Anthropic SDK directly — `parse` makes one Haiku call that returns strict JSON for slot-filling or an out-of-scope verdict, and `narrate` makes one Haiku call to phrase the terminal state. They do **not** go through `langchain_anthropic`. The orchestration layer (LangGraph) and the tool layer (the Phase 1.6b MCP server, called in-process) are kept as separate concerns: the graph decides *what happens when*, the MCP tools *do the work*, and neither leaks into the other.
+
+The graph is invoked stateless per turn. Each user message constructs a fresh `GraphState(user_message=...)` and runs it to completion; the conversation history lives in Streamlit's session state for display only, and the `parse` node sees just the latest message.
+
+## Consequences
+
+The control flow is now a diagram I can point at, and every branch off it is a test. `test_graph_branches.py` drives the five conditional paths — missing fields, out of scope, a predict-tool fault, a postal lookup miss, and a postal lookup that resolves the town and carries the prediction — by stubbing the LLM nodes with deterministic doubles and handing the MCP nodes fake clients, so the assertions turn on routing, not on phrasing or live services. The old loop could only be tested by mocking the model's tool-call sequence, which tested the mock as much as the code. Error handling is localised: a failure in the postal lookup or the prediction tool is caught in that node, recorded on the state, and narrated gracefully, instead of surfacing as an exception or a confused model turn.
+
+Calling the Anthropic SDK directly inside the nodes, rather than through `langchain_anthropic`, is a deliberate trade-off. It keeps one Anthropic client pattern across the whole codebase — the same `Anthropic(api_key=...)` singleton and `cache_control` configuration the legacy agent used — and avoids pulling LangChain's message-and-model abstractions in just to make two calls. The cost is that the nodes are not portable to a different LLM provider without editing them; for a single-provider portfolio project that is the right side of the trade. LangGraph earns its place here as the orchestration graph; LangChain's model wrappers would have been weight without benefit.
+
+The stateless-per-turn invocation is the main limitation I am accepting. A follow-up like "what about a 5-room instead" starts a fresh graph run that re-parses only the new message, so the chat cannot yet refine a previous answer conversationally. Multi-turn awareness — threading prior turns into the parse node, MessagesPlaceholder-style — is a deliberate deferral, not an oversight; the per-turn graph is simpler to reason about and test, and the UI still shows the full conversation. Adding turn memory later is a change to one node's input, not to the graph's shape.
+
+One implementation quirk is worth recording because it surprised me and will surprise the next reader. `graph.ainvoke(state)` does not return a `GraphState` — it returns a plain `dict` of the merged channel values. Reading a field off the result therefore needs `GraphState(**result)` to reconstruct the typed object first. The Streamlit integration and the tests both do this, and the `GraphState` docstring notes it. It is a LangGraph convention (nodes return dict updates, the runtime merges them into channels), not a bug, but it reads as one until you know.
+
+The legacy `chat_agent.py` stays in the tree for now — Streamlit simply stops calling it. Removing it is a separate cleanup once the graph has proven itself in use, kept out of this change so the orchestration swap is reviewable on its own.
+
+## Alternatives considered
+
+**Keep the direct Anthropic tool-use loop.** It was already working and is genuinely compact for three tools. Rejected because the model owned the control flow: validation, ordering, and the predict-then-explain sequence were all emergent from the model's tool-calling rather than explicit, testable code. The branch coverage and per-step error handling I wanted are exactly what an explicit graph gives and an LLM-driven loop cannot.
+
+**Use `langchain_anthropic` with LangGraph's prebuilt agent helpers.** This is the idiomatic LangGraph-plus-LangChain path and would have handed me a ReAct-style agent almost for free. Rejected because it reintroduces the same model-owns-the-flow problem the prebuilt agent is built around, and because it pulls LangChain's model and message abstractions across the whole chat path to wrap two Haiku calls I can make directly. I wanted LangGraph for its graph, not LangChain for its agent.
+
+**A pipeline orchestrator wrapping the work (ZenML, Prefect, or similar).** Heavier machinery aimed at scheduled, multi-step data and training pipelines, not a sub-second interactive chat turn. It is also on the project's explicit out-of-scope list. Rejected as a category error: the problem is request-time orchestration of a handful of in-process steps, which a compiled state graph models exactly, with none of the scheduler, persistence, or DAG-runner weight those tools carry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "streamlit>=1.31",
     "anthropic>=0.40",
     "fastmcp>=3.4,<4.0",
+    "langgraph~=1.2",
 ]
 
 [project.optional-dependencies]

--- a/src/ui/chat_app/config.py
+++ b/src/ui/chat_app/config.py
@@ -8,12 +8,19 @@ class ChatConfig(BaseSettings):
     """Settings for the chat app.
 
     All fields are overridable via environment variables of the same name
-    (case-insensitive). ANTHROPIC_API_KEY must be set in the environment —
-    the chat agent uses the Anthropic API directly.
+    (case-insensitive). ANTHROPIC_API_KEY must be set either in the
+    environment or in a ``.env`` file at the project root — the chat graph
+    uses the Anthropic API directly. Environment variables take precedence
+    over ``.env`` entries.
     """
 
     anthropic_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
     api_base_url: str = "http://127.0.0.1:8000"
     request_timeout_seconds: int = 10
 
-    model_config = {"populate_by_name": True}
+    model_config = {
+        "populate_by_name": True,
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }

--- a/src/ui/chat_app/graph/__init__.py
+++ b/src/ui/chat_app/graph/__init__.py
@@ -1,0 +1,12 @@
+"""LangGraph orchestration for the HDB chat app.
+
+The graph replaces the chat agent's tool-use loop with an explicit state machine:
+``parse -> postal_lookup -> validate -> (predict -> explain) -> narrate``. Each
+node owns one step with its own error handling, and the tool layer underneath is
+the Phase 1.6b MCP server, invoked in-process via :mod:`ui.chat_app.graph.mcp_client`.
+"""
+
+from ui.chat_app.graph.graph_builder import build_graph
+from ui.chat_app.graph.state import GraphState
+
+__all__ = ["GraphState", "build_graph"]

--- a/src/ui/chat_app/graph/graph_builder.py
+++ b/src/ui/chat_app/graph/graph_builder.py
@@ -1,0 +1,51 @@
+"""Assemble the chat orchestration graph.
+
+Wires the six nodes into a :class:`~langgraph.graph.StateGraph` over
+:class:`~ui.chat_app.graph.state.GraphState`:
+
+    parse -> postal_lookup -> validate --(ready)--> predict -> explain -> narrate -> END
+                                       \\--(else)----------------------> narrate -> END
+
+After ``validate``, a conditional edge routes ``ready_to_predict`` states through
+prediction and explanation, and every other terminal status
+(``needs_follow_up``, ``out_of_scope``, ``error``) straight to ``narrate``.
+Checkpointing is left at LangGraph's in-memory default — no persistence yet.
+"""
+
+from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+from ui.chat_app.graph.nodes import explain, lookup, narrate, parse, predict, validate
+from ui.chat_app.graph.state import GraphState
+
+
+def _after_validate(state: GraphState) -> str:
+    """Route to prediction when ready, otherwise to narration."""
+    if state.status == "ready_to_predict":
+        return "predict"
+    return "narrate"
+
+
+def build_graph() -> CompiledStateGraph:
+    """Build and compile the chat orchestration graph."""
+    graph = StateGraph(GraphState)
+    graph.add_node("parse", parse.run)
+    graph.add_node("postal_lookup", lookup.run)
+    graph.add_node("validate", validate.run)
+    graph.add_node("predict", predict.run)
+    graph.add_node("explain", explain.run)
+    graph.add_node("narrate", narrate.run)
+
+    graph.set_entry_point("parse")
+    graph.add_edge("parse", "postal_lookup")
+    graph.add_edge("postal_lookup", "validate")
+    graph.add_conditional_edges(
+        "validate",
+        _after_validate,
+        {"predict": "predict", "narrate": "narrate"},
+    )
+    graph.add_edge("predict", "explain")
+    graph.add_edge("explain", "narrate")
+    graph.add_edge("narrate", END)
+
+    return graph.compile()

--- a/src/ui/chat_app/graph/mcp_client.py
+++ b/src/ui/chat_app/graph/mcp_client.py
@@ -1,0 +1,127 @@
+"""In-process MCP client used by the orchestration graph's nodes.
+
+Nodes reach the Phase 1.6b tools through this wrapper rather than importing the
+tool functions directly. Routing through FastMCP's in-process ``Client`` keeps
+the graph honest — it exercises the same tool-call path an external MCP client
+(Claude Desktop, Cursor) uses, including schema validation and the
+``structured_content`` envelope — without spawning a subprocess or opening a
+socket. The MCP server loads the ``@champion`` model once and reuses it, so the
+cost here is the tool call, not a model reload.
+
+The wrapper is a lazily-constructed module-level singleton, mirroring the
+``_client`` pattern in :mod:`ui.chat_app.chat_agent`.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from mcp_server.server import mcp
+
+logger = logging.getLogger(__name__)
+
+
+class MCPToolClient:
+    """Async wrapper over FastMCP's in-process ``Client``.
+
+    Each method opens a short-lived ``Client(mcp)`` context, calls one tool, and
+    returns its structured payload. ``get_model_info`` and
+    ``find_similar_transactions`` are intentionally absent — the current chat
+    flow does not call them.
+    """
+
+    async def lookup_postal_code(self, postal_code: int) -> dict[str, Any] | None:
+        """Resolve a postal code to an address, or ``None`` if it is not in the table.
+
+        The MCP tool raises :class:`ToolError` for a postal code absent from the
+        lookup table. For the chat flow that is an expected miss — the user may
+        have typed an unknown or non-HDB code — so it maps to ``None`` rather
+        than surfacing as a failure. Genuine tool faults raise other exception
+        types and propagate to the calling node, which records them on the state.
+        """
+        try:
+            async with Client(mcp) as client:
+                result = await client.call_tool("lookup_postal_code", {"postal_code": postal_code})
+        except ToolError:
+            logger.info("Postal code %s not found in lookup table", postal_code)
+            return None
+        return result.structured_content
+
+    async def predict_price(
+        self,
+        *,
+        town: str,
+        flat_type: str,
+        floor_area_sqm: float,
+        lease_commence_date: int,
+        month: str,
+    ) -> dict[str, Any]:
+        """Predict a single flat's resale price.
+
+        Returns the tool's structured payload: ``predicted_resale_price``,
+        ``model_version``, and ``model_alias``.
+        """
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "predict_price",
+                {
+                    "town": town,
+                    "flat_type": flat_type,
+                    "floor_area_sqm": floor_area_sqm,
+                    "lease_commence_date": lease_commence_date,
+                    "month": month,
+                },
+            )
+        return _require_structured(result.structured_content, "predict_price")
+
+    async def explain_prediction(
+        self,
+        *,
+        town: str,
+        flat_type: str,
+        floor_area_sqm: float,
+        lease_commence_date: int,
+        month: str,
+    ) -> dict[str, Any]:
+        """Explain a single prediction with SHAP feature contributions.
+
+        Returns the tool's structured payload, including ``top_contributors``
+        (aggregated, human-readable labels) and ``base_value``.
+        """
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "explain_prediction",
+                {
+                    "town": town,
+                    "flat_type": flat_type,
+                    "floor_area_sqm": floor_area_sqm,
+                    "lease_commence_date": lease_commence_date,
+                    "month": month,
+                },
+            )
+        return _require_structured(result.structured_content, "explain_prediction")
+
+
+def _require_structured(payload: dict[str, Any] | None, tool: str) -> dict[str, Any]:
+    """Assert a tool returned a structured payload, narrowing the type for callers.
+
+    The HDB tools all return TypedDicts, so ``structured_content`` is always a
+    dict in practice. A ``None`` here means the tool contract changed — fail loud
+    rather than hand a node a silent ``None``.
+    """
+    if payload is None:
+        raise RuntimeError(f"MCP tool {tool!r} returned no structured content")
+    return payload
+
+
+_client: MCPToolClient | None = None
+
+
+def get_client() -> MCPToolClient:
+    """Return the module-level :class:`MCPToolClient`, constructing it on first use."""
+    global _client
+    if _client is None:
+        _client = MCPToolClient()
+    return _client

--- a/src/ui/chat_app/graph/nodes/__init__.py
+++ b/src/ui/chat_app/graph/nodes/__init__.py
@@ -1,0 +1,8 @@
+"""Graph nodes, one module per step.
+
+Each module exposes a single ``run`` coroutine taking the current
+:class:`~ui.chat_app.graph.state.GraphState` and returning a dict of the fields
+it changed. ``parse`` and ``narrate`` are Day 1 stubs returning canonical data;
+``postal_lookup``, ``validate``, ``predict``, and ``explain`` are the real
+implementations.
+"""

--- a/src/ui/chat_app/graph/nodes/__init__.py
+++ b/src/ui/chat_app/graph/nodes/__init__.py
@@ -2,7 +2,7 @@
 
 Each module exposes a single ``run`` coroutine taking the current
 :class:`~ui.chat_app.graph.state.GraphState` and returning a dict of the fields
-it changed. ``parse`` and ``narrate`` are Day 1 stubs returning canonical data;
-``postal_lookup``, ``validate``, ``predict``, and ``explain`` are the real
-implementations.
+it changed. ``parse`` and ``narrate`` make Anthropic Claude Haiku calls;
+``postal_lookup``, ``predict``, and ``explain`` call the MCP tools; ``validate``
+is pure Python.
 """

--- a/src/ui/chat_app/graph/nodes/_features.py
+++ b/src/ui/chat_app/graph/nodes/_features.py
@@ -1,0 +1,28 @@
+"""Shared field resolution for the prediction and explanation nodes.
+
+Both nodes need the same five model inputs, and both prefer a town the parse
+node extracted directly over one the postal lookup resolved. Centralising that
+here keeps the two nodes in lockstep — they can never disagree on which town to
+predict for.
+"""
+
+from typing import Any
+
+from ui.chat_app.graph.state import GraphState
+
+
+def model_fields(state: GraphState) -> dict[str, Any]:
+    """Return the five model-input fields for an MCP prediction or explanation call.
+
+    Prefers ``state.town`` over ``state.resolved_town`` so an explicit town the
+    user gave wins over one inferred from a postal code. Call only after
+    validation has set ``status == "ready_to_predict"``, which guarantees every
+    value here is present.
+    """
+    return {
+        "town": state.town or state.resolved_town,
+        "flat_type": state.flat_type,
+        "floor_area_sqm": state.floor_area_sqm,
+        "lease_commence_date": state.lease_commence_date,
+        "month": state.month,
+    }

--- a/src/ui/chat_app/graph/nodes/explain.py
+++ b/src/ui/chat_app/graph/nodes/explain.py
@@ -1,0 +1,40 @@
+"""explain node — call the MCP SHAP explanation tool.
+
+Runs only after a successful prediction. It calls the MCP ``explain_prediction``
+tool and records the top contributors (already aggregated to one entry per
+source feature with human-readable labels) and the model's base value. A tool
+fault sets ``status = "error"``.
+"""
+
+import logging
+
+from ui.chat_app.graph.mcp_client import get_client
+from ui.chat_app.graph.nodes._features import model_fields
+from ui.chat_app.graph.state import GraphState
+
+logger = logging.getLogger(__name__)
+
+
+async def run(state: GraphState) -> dict:
+    """Record SHAP top contributors and base value for the prediction.
+
+    No-ops unless ``status == "ready_to_predict"`` and a price has been set.
+    Records an error update if the explanation tool call fails.
+    """
+    if state.status != "ready_to_predict" or state.predicted_price is None:
+        return {}
+
+    client = get_client()
+    try:
+        result = await client.explain_prediction(**model_fields(state))
+    except Exception as exc:  # any tool fault becomes graph-visible state
+        logger.warning("explain failed: %s: %s", type(exc).__name__, exc)
+        return {
+            "error": f"Explanation failed: {type(exc).__name__}: {exc}",
+            "status": "error",
+        }
+
+    return {
+        "top_contributors": result["top_contributors"],
+        "base_value": result["base_value"],
+    }

--- a/src/ui/chat_app/graph/nodes/lookup.py
+++ b/src/ui/chat_app/graph/nodes/lookup.py
@@ -1,0 +1,40 @@
+"""postal_lookup node — resolve a postal code to a town via the MCP tool.
+
+When the parse node extracted a postal code, this node calls the MCP
+``lookup_postal_code`` tool and records the resolved town on the state. A postal
+code absent from the lookup table is not an error — the wrapper returns ``None``
+and the node passes the state through unchanged, leaving any town the user gave
+intact. Only a genuine tool fault sets ``status = "error"``.
+"""
+
+import logging
+
+from ui.chat_app.graph.mcp_client import get_client
+from ui.chat_app.graph.state import GraphState
+
+logger = logging.getLogger(__name__)
+
+
+async def run(state: GraphState) -> dict:
+    """Resolve ``state.postal_code`` to ``resolved_town`` when possible.
+
+    No-ops (returns an empty update) when there is no postal code, when the code
+    is not in the lookup table, or when the resolved address has no HDB town.
+    Records an error update if the tool call itself fails.
+    """
+    if state.postal_code is None:
+        return {}
+
+    client = get_client()
+    try:
+        result = await client.lookup_postal_code(state.postal_code)
+    except Exception as exc:  # any tool fault becomes graph-visible state
+        logger.warning("postal_lookup failed: %s: %s", type(exc).__name__, exc)
+        return {
+            "error": f"Postal lookup failed: {type(exc).__name__}: {exc}",
+            "status": "error",
+        }
+
+    if result is None or result.get("town") is None:
+        return {}
+    return {"resolved_town": result["town"]}

--- a/src/ui/chat_app/graph/nodes/narrate.py
+++ b/src/ui/chat_app/graph/nodes/narrate.py
@@ -1,35 +1,132 @@
-"""narrate node — turn the final state into user-facing text.
+"""narrate node — turn the final state into user-facing text via Claude Haiku.
 
-Day 1 stub: deterministic string formatting per terminal status. Day 2 replaces
-the ``ready_to_predict`` branch with a real Anthropic narration call that frames
-the price and contributors conversationally; the other branches stay simple.
+The node picks one of three branches off ``state.status`` and makes a single
+Anthropic call to phrase the reply. Each branch supplies a different system
+prompt and context block; the call itself is shared:
+
+- ``ready_to_predict`` — narrate the predicted price and its top contributors;
+- ``needs_follow_up`` — ask one concise question for the missing fields;
+- ``out_of_scope`` / ``error`` — decline or apologise without leaking internals.
+
+The Anthropic client is a module-level singleton mirroring the pattern in
+:mod:`ui.chat_app.chat_agent`.
 """
 
+import logging
+from typing import Any
+
+from anthropic import Anthropic
+
+from ui.chat_app.chat_agent import MODEL
+from ui.chat_app.config import ChatConfig
 from ui.chat_app.graph.state import GraphState
 
-_DEFAULT_DECLINE = (
+logger = logging.getLogger(__name__)
+
+_config = ChatConfig()
+_client = Anthropic(api_key=_config.anthropic_api_key or None)
+
+# Used only if the LLM call fails, so the user still gets a coherent reply.
+_FALLBACK_DECLINE = (
     "I can only estimate Singapore HDB resale flat prices. Please ask about an HDB flat."
+)
+_FALLBACK_ERROR = (
+    "Sorry, something went wrong while estimating that price. "
+    "Please try again, or contact support if it persists."
+)
+
+# Human-friendly field labels for the follow-up question.
+_FIELD_LABELS = {
+    "town": "the HDB town",
+    "flat_type": "the flat type (e.g. 4 ROOM)",
+    "floor_area_sqm": "the floor area in square metres",
+    "lease_commence_date": "the year the lease started",
+    "month": "the transaction month",
+}
+
+_PREDICT_SYSTEM = (
+    "You are a friendly assistant that presents a Singapore HDB resale price "
+    "estimate. You are given the prediction and the top model contributors as "
+    "context — do not invent or recompute any numbers. Reply in British English, "
+    "no emojis. Lead with the headline price, then a short 'What's driving this "
+    "price' list of the contributors (note whether each pushes the price up or "
+    "down), then a one-line caveat that the figure is an estimate. Format prices "
+    "with a leading S$ and comma thousands separators, e.g. S$586,888."
+)
+_FOLLOW_UP_SYSTEM = (
+    "You are a friendly assistant collecting the details needed to estimate a "
+    "Singapore HDB resale price. The user's message was missing some fields. Ask "
+    "one short, natural follow-up question that requests all of the missing "
+    "fields together — do not ask several separate questions. Reply in British "
+    "English, no emojis."
+)
+_DECLINE_SYSTEM = (
+    "You are a friendly assistant that only estimates Singapore HDB resale flat "
+    "prices. Politely decline the user's request in one or two sentences, using "
+    "the given reason if helpful, and steer them towards asking about an HDB "
+    "resale flat. Reply in British English, no emojis."
+)
+_ERROR_SYSTEM = (
+    "You are a friendly assistant for Singapore HDB resale price estimates. "
+    "Something went wrong on our side. Briefly apologise in one or two sentences "
+    "and suggest the user try again or contact support. Do not mention error "
+    "codes, stack traces, or internal details. Reply in British English, no "
+    "emojis."
 )
 
 
-async def run(state: GraphState) -> dict:
-    """Write ``response_text`` from the terminal status (stub).
+def _predict_context(state: GraphState) -> str:
+    price = f"S${state.predicted_price:,.0f}" if state.predicted_price is not None else "unknown"
+    lines = [
+        f"Predicted resale price: {price}",
+        f"Model version: {state.model_version}",
+        "Top contributors (signed Singapore-dollar impact on the price):",
+    ]
+    for contributor in state.top_contributors[:3]:
+        lines.append(f"- {contributor['feature']}: {contributor['contribution']:+,.0f}")
+    return "\n".join(lines)
 
-    - ``ready_to_predict`` with a price: state the prediction, model version, and
-      top three contributors.
-    - ``needs_follow_up``: ask for the missing fields.
-    - ``out_of_scope`` or ``error``: return the recorded error or a decline message.
-    """
+
+def _follow_up_context(state: GraphState) -> str:
+    labels = [_FIELD_LABELS.get(field, field) for field in state.missing_fields]
+    return "The user still needs to provide: " + ", ".join(labels)
+
+
+def _decline_context(state: GraphState) -> str:
+    if state.parse_reasoning:
+        return f"Reason the request is out of scope: {state.parse_reasoning}"
+    return "The request is not about a Singapore HDB resale flat."
+
+
+def _branch(state: GraphState) -> tuple[str, str, str]:
+    """Return (system_prompt, context, fallback_text) for the current status."""
     if state.status == "ready_to_predict" and state.predicted_price is not None:
-        top_three = ", ".join(c["feature"] for c in state.top_contributors[:3])
-        text = (
-            f"Predicted price: S${state.predicted_price:.0f}, "
-            f"model v{state.model_version}, "
-            f"top contributors: {top_three}"
-        )
-        return {"response_text": text}
-
+        return _PREDICT_SYSTEM, _predict_context(state), _FALLBACK_ERROR
     if state.status == "needs_follow_up":
-        return {"response_text": f"Please provide: {', '.join(state.missing_fields)}"}
+        return _FOLLOW_UP_SYSTEM, _follow_up_context(state), _FALLBACK_DECLINE
+    if state.status == "out_of_scope":
+        return _DECLINE_SYSTEM, _decline_context(state), _FALLBACK_DECLINE
+    return _ERROR_SYSTEM, "An internal step failed.", _FALLBACK_ERROR
 
-    return {"response_text": state.error or _DEFAULT_DECLINE}
+
+async def run(state: GraphState) -> dict[str, Any]:
+    """Write ``response_text`` by narrating the terminal state with Claude Haiku.
+
+    Falls back to a fixed message for the branch if the LLM call fails, so the
+    user always receives a coherent reply rather than an exception.
+    """
+    system, context, fallback = _branch(state)
+
+    try:
+        resp = _client.messages.create(
+            model=MODEL,
+            max_tokens=512,
+            system=[{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}],
+            messages=[{"role": "user", "content": context}],
+        )
+    except Exception as exc:  # the reply must not depend on the LLM being reachable
+        logger.warning("narrate call failed: %s: %s", type(exc).__name__, exc)
+        return {"response_text": fallback}
+
+    text = "".join(b.text for b in resp.content if b.type == "text").strip()
+    return {"response_text": text or fallback}

--- a/src/ui/chat_app/graph/nodes/narrate.py
+++ b/src/ui/chat_app/graph/nodes/narrate.py
@@ -1,0 +1,35 @@
+"""narrate node — turn the final state into user-facing text.
+
+Day 1 stub: deterministic string formatting per terminal status. Day 2 replaces
+the ``ready_to_predict`` branch with a real Anthropic narration call that frames
+the price and contributors conversationally; the other branches stay simple.
+"""
+
+from ui.chat_app.graph.state import GraphState
+
+_DEFAULT_DECLINE = (
+    "I can only estimate Singapore HDB resale flat prices. Please ask about an HDB flat."
+)
+
+
+async def run(state: GraphState) -> dict:
+    """Write ``response_text`` from the terminal status (stub).
+
+    - ``ready_to_predict`` with a price: state the prediction, model version, and
+      top three contributors.
+    - ``needs_follow_up``: ask for the missing fields.
+    - ``out_of_scope`` or ``error``: return the recorded error or a decline message.
+    """
+    if state.status == "ready_to_predict" and state.predicted_price is not None:
+        top_three = ", ".join(c["feature"] for c in state.top_contributors[:3])
+        text = (
+            f"Predicted price: S${state.predicted_price:.0f}, "
+            f"model v{state.model_version}, "
+            f"top contributors: {top_three}"
+        )
+        return {"response_text": text}
+
+    if state.status == "needs_follow_up":
+        return {"response_text": f"Please provide: {', '.join(state.missing_fields)}"}
+
+    return {"response_text": state.error or _DEFAULT_DECLINE}

--- a/src/ui/chat_app/graph/nodes/parse.py
+++ b/src/ui/chat_app/graph/nodes/parse.py
@@ -1,0 +1,28 @@
+"""parse node — extract model inputs from the user's message.
+
+Day 1 stub: returns a fixed extraction for the canonical test input ("3 room
+flat in Tampines, postal 528003") regardless of the actual message, so the rest
+of the graph has deterministic, fully-populated inputs to run against. Day 2
+replaces the body with a real Anthropic call that does slot-filling from free
+text.
+"""
+
+from ui.chat_app.graph.state import GraphState
+
+
+async def run(state: GraphState) -> dict:
+    """Return the canonical extracted fields (stub).
+
+    The values match the project's standing test input: a Tampines 4-room flat
+    with a postal code. Postal 528003 is deliberately one that is absent from the
+    lookup table, so ``postal_lookup`` exercises its miss path while ``town``
+    being present keeps the happy path intact.
+    """
+    return {
+        "town": "TAMPINES",
+        "flat_type": "4 ROOM",
+        "floor_area_sqm": 95.0,
+        "lease_commence_date": 1985,
+        "month": "2024-06",
+        "postal_code": 528003,
+    }

--- a/src/ui/chat_app/graph/nodes/parse.py
+++ b/src/ui/chat_app/graph/nodes/parse.py
@@ -1,28 +1,152 @@
-"""parse node — extract model inputs from the user's message.
+"""parse node — extract model inputs from the user's message via Claude Haiku.
 
-Day 1 stub: returns a fixed extraction for the canonical test input ("3 room
-flat in Tampines, postal 528003") regardless of the actual message, so the rest
-of the graph has deterministic, fully-populated inputs to run against. Day 2
-replaces the body with a real Anthropic call that does slot-filling from free
-text.
+A single Anthropic call does the slot-filling. The model returns a strict JSON
+object: a ``status`` (``extracted`` or ``out_of_scope``), a brief ``reasoning``
+string, and the six fields the downstream graph needs. Non-HDB property questions
+(condos, landed, commercial) come back ``out_of_scope`` so the graph declines
+without touching the model. A response that does not parse as the expected JSON
+sets ``status = "error"`` rather than guessing at fields.
+
+The Anthropic client is a module-level singleton mirroring the pattern in
+:mod:`ui.chat_app.chat_agent`, from which the model id and the town/flat-type
+vocabularies are imported to keep a single source of truth.
 """
 
+import json
+import logging
+from datetime import date
+from typing import Any
+
+from anthropic import Anthropic
+
+from ui.chat_app.chat_agent import FLAT_TYPES, MODEL, TOWNS
+from ui.chat_app.config import ChatConfig
 from ui.chat_app.graph.state import GraphState
 
+logger = logging.getLogger(__name__)
 
-async def run(state: GraphState) -> dict:
-    """Return the canonical extracted fields (stub).
+_config = ChatConfig()
+# Pass None when the field is empty so the SDK reads ANTHROPIC_API_KEY from the
+# environment rather than treating an empty string as a set (but invalid) key.
+_client = Anthropic(api_key=_config.anthropic_api_key or None)
 
-    The values match the project's standing test input: a Tampines 4-room flat
-    with a postal code. Postal 528003 is deliberately one that is absent from the
-    lookup table, so ``postal_lookup`` exercises its miss path while ``town``
-    being present keeps the happy path intact.
+_SYSTEM_PROMPT_TEMPLATE = (
+    "You extract structured fields from a user's plain-English question about "
+    "Singapore HDB resale flat prices. You never answer the question or estimate "
+    "a price yourself — you only fill a field set.\n\n"
+    "Today's date is {today}. The current month is {current_month}.\n\n"
+    "Return a single JSON object and nothing else, with exactly these keys:\n"
+    '  "status": "extracted" or "out_of_scope"\n'
+    '  "reasoning": a brief reason for the status\n'
+    '  "fields": an object with these keys, each null if the user did not give it:\n'
+    '    "town": one of the HDB towns below, uppercased, or null\n'
+    '    "flat_type": one of the flat types below, uppercased, or null\n'
+    '    "floor_area_sqm": a number in square metres, or null\n'
+    '    "lease_commence_date": the four-digit year the lease began, or null\n'
+    '    "month": the transaction month as "YYYY-MM", or null\n'
+    '    "postal_code": a six-digit Singapore postal code as an integer, or null\n\n'
+    "Rules:\n"
+    "- Set status to out_of_scope for any question about non-HDB property — "
+    "condominiums, landed houses, commercial units, or property outside "
+    "Singapore. Leave all fields null in that case.\n"
+    "- Leave a field null if the user did not provide it. Do not invent values.\n"
+    "- The one exception is month: if the user gives no transaction month, set it "
+    "to the current month ({current_month}).\n"
+    "- Normalise town and flat_type to the exact uppercase vocabulary values "
+    'below (for example "tampines" becomes "TAMPINES", "4-room" becomes '
+    '"4 ROOM").\n'
+    "- A postal code helps resolve the town later; it is not itself a model "
+    "input, so record it in postal_code and still leave town null unless the "
+    "user named the town.\n\n"
+    "Valid towns: {towns}\n"
+    "Valid flat types: {flat_types}"
+)
+
+_EXPECTED_FIELD_KEYS = {
+    "town",
+    "flat_type",
+    "floor_area_sqm",
+    "lease_commence_date",
+    "month",
+    "postal_code",
+}
+
+
+def _system_prompt() -> str:
+    today = date.today()
+    return _SYSTEM_PROMPT_TEMPLATE.format(
+        today=today.strftime("%d %B %Y"),
+        current_month=today.strftime("%Y-%m"),
+        towns=", ".join(TOWNS),
+        flat_types=", ".join(FLAT_TYPES),
+    )
+
+
+def _error(reason: str) -> dict[str, Any]:
+    """Build the state update for a parse failure, logging the reason for debugging."""
+    logger.warning("parse failed: %s", reason)
+    return {"status": "error", "parse_reasoning": reason}
+
+
+async def run(state: GraphState) -> dict[str, Any]:
+    """Extract the model fields from ``state.user_message`` via a Claude Haiku call.
+
+    Returns one of three shapes:
+
+    - extracted: the six fields plus ``status = "pending"`` so the graph
+      continues to ``postal_lookup``;
+    - out_of_scope: ``status = "out_of_scope"`` and a ``parse_reasoning`` the
+      narrate node uses to decline;
+    - error: ``status = "error"`` when the model's reply does not parse as the
+      expected JSON.
     """
+    try:
+        resp = _client.messages.create(
+            model=MODEL,
+            max_tokens=512,
+            system=[
+                {
+                    "type": "text",
+                    "text": _system_prompt(),
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[
+                {"role": "user", "content": state.user_message},
+                # Prefill the opening brace so the model continues with JSON only.
+                {"role": "assistant", "content": "{"},
+            ],
+        )
+    except Exception as exc:  # network or API fault becomes an error verdict
+        return _error(f"Anthropic call failed: {type(exc).__name__}: {exc}")
+
+    raw = "{" + "".join(b.text for b in resp.content if b.type == "text")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return _error(f"model returned non-JSON output: {exc}: {raw!r}")
+
+    status = payload.get("status")
+    reasoning = payload.get("reasoning")
+
+    if status == "out_of_scope":
+        return {"status": "out_of_scope", "parse_reasoning": reasoning}
+
+    if status != "extracted":
+        return _error(f"unexpected status {status!r} in {payload!r}")
+
+    fields = payload.get("fields")
+    if not isinstance(fields, dict) or not set(fields) >= _EXPECTED_FIELD_KEYS:
+        return _error(f"missing or malformed fields object in {payload!r}")
+
+    town = fields["town"]
+    flat_type = fields["flat_type"]
     return {
-        "town": "TAMPINES",
-        "flat_type": "4 ROOM",
-        "floor_area_sqm": 95.0,
-        "lease_commence_date": 1985,
-        "month": "2024-06",
-        "postal_code": 528003,
+        "town": town.upper() if isinstance(town, str) else None,
+        "flat_type": flat_type.upper() if isinstance(flat_type, str) else None,
+        "floor_area_sqm": fields["floor_area_sqm"],
+        "lease_commence_date": fields["lease_commence_date"],
+        "month": fields["month"],
+        "postal_code": fields["postal_code"],
+        "status": "pending",
     }

--- a/src/ui/chat_app/graph/nodes/predict.py
+++ b/src/ui/chat_app/graph/nodes/predict.py
@@ -1,0 +1,40 @@
+"""predict node — call the MCP prediction tool.
+
+Runs only when validation marked the state ``ready_to_predict``. It resolves the
+town (explicit over looked-up), calls the MCP ``predict_price`` tool, and records
+the price and the serving model's version. A tool fault sets ``status = "error"``
+so the graph routes straight to narrate.
+"""
+
+import logging
+
+from ui.chat_app.graph.mcp_client import get_client
+from ui.chat_app.graph.nodes._features import model_fields
+from ui.chat_app.graph.state import GraphState
+
+logger = logging.getLogger(__name__)
+
+
+async def run(state: GraphState) -> dict:
+    """Predict the resale price and record it with the model version.
+
+    No-ops unless ``status == "ready_to_predict"``. Records an error update if
+    the prediction tool call fails.
+    """
+    if state.status != "ready_to_predict":
+        return {}
+
+    client = get_client()
+    try:
+        result = await client.predict_price(**model_fields(state))
+    except Exception as exc:  # any tool fault becomes graph-visible state
+        logger.warning("predict failed: %s: %s", type(exc).__name__, exc)
+        return {
+            "error": f"Prediction failed: {type(exc).__name__}: {exc}",
+            "status": "error",
+        }
+
+    return {
+        "predicted_price": result["predicted_resale_price"],
+        "model_version": result["model_version"],
+    }

--- a/src/ui/chat_app/graph/nodes/validate.py
+++ b/src/ui/chat_app/graph/nodes/validate.py
@@ -1,0 +1,35 @@
+"""validate node — check the five model fields are present.
+
+Pure Python, no tool or LLM call. A town from either ``town`` or
+``resolved_town`` satisfies the town requirement. The node sets ``status`` to
+``ready_to_predict`` when all five fields are present and ``needs_follow_up``
+otherwise, listing the absent fields in ``missing_fields`` so the narrate node
+can ask for them.
+"""
+
+from ui.chat_app.graph.state import GraphState
+
+REQUIRED_FIELDS = ("town", "flat_type", "floor_area_sqm", "lease_commence_date", "month")
+
+
+async def run(state: GraphState) -> dict:
+    """Set ``status`` and ``missing_fields`` from which model inputs are present.
+
+    Passes through unchanged if an earlier node already set ``status = "error"``,
+    so a tool fault upstream is not masked by a validation verdict.
+    """
+    if state.status == "error":
+        return {}
+
+    present = {
+        "town": state.town or state.resolved_town,
+        "flat_type": state.flat_type,
+        "floor_area_sqm": state.floor_area_sqm,
+        "lease_commence_date": state.lease_commence_date,
+        "month": state.month,
+    }
+    missing = [field for field in REQUIRED_FIELDS if present[field] is None]
+
+    if missing:
+        return {"missing_fields": missing, "status": "needs_follow_up"}
+    return {"missing_fields": [], "status": "ready_to_predict"}

--- a/src/ui/chat_app/graph/nodes/validate.py
+++ b/src/ui/chat_app/graph/nodes/validate.py
@@ -15,10 +15,11 @@ REQUIRED_FIELDS = ("town", "flat_type", "floor_area_sqm", "lease_commence_date",
 async def run(state: GraphState) -> dict:
     """Set ``status`` and ``missing_fields`` from which model inputs are present.
 
-    Passes through unchanged if an earlier node already set ``status = "error"``,
-    so a tool fault upstream is not masked by a validation verdict.
+    Only runs when ``status == "pending"``. A terminal status set upstream — an
+    ``error`` from a tool fault or an ``out_of_scope`` verdict from the parse
+    node — passes through unchanged so a validation verdict cannot mask it.
     """
-    if state.status == "error":
+    if state.status != "pending":
         return {}
 
     present = {

--- a/src/ui/chat_app/graph/state.py
+++ b/src/ui/chat_app/graph/state.py
@@ -1,0 +1,66 @@
+"""State schema for the chat orchestration graph.
+
+The graph threads a single :class:`GraphState` through every node. Nodes never
+mutate the state in place; each returns a dict of changed fields and LangGraph
+merges it into a fresh state between steps. ``model_copy(update=...)`` produces
+the same merged result outside the graph, which is what the node unit tests use.
+
+Field groups follow the flow: the user message comes in, ``parse`` extracts the
+model inputs, ``postal_lookup`` resolves a town from a postal code, ``validate``
+sets ``status`` and ``missing_fields``, ``predict`` and ``explain`` fill the
+prediction and SHAP outputs, and ``narrate`` writes ``response_text``.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+Status = Literal[
+    "pending",
+    "ready_to_predict",
+    "needs_follow_up",
+    "out_of_scope",
+    "error",
+]
+
+
+class GraphState(BaseModel):
+    """Single state object threaded through the orchestration graph.
+
+    Optional fields default to ``None`` until the node responsible for them runs,
+    so any node can inspect what earlier nodes did or did not produce. List fields
+    default to empty via ``default_factory`` to avoid the shared-mutable-default
+    trap.
+    """
+
+    # Input.
+    user_message: str
+
+    # Extracted by the parse node (None until parsed).
+    town: str | None = None
+    flat_type: str | None = None
+    floor_area_sqm: float | None = None
+    lease_commence_date: int | None = None
+    month: str | None = None
+    postal_code: int | None = None
+
+    # Output of the postal lookup (None unless a postal code was given and resolved).
+    resolved_town: str | None = None
+
+    # Validation result.
+    missing_fields: list[str] = Field(default_factory=list)
+    status: Status = "pending"
+
+    # Prediction outputs.
+    predicted_price: float | None = None
+    model_version: int | None = None
+
+    # Explanation outputs.
+    top_contributors: list[dict] = Field(default_factory=list)
+    base_value: float | None = None
+
+    # Final response to the user.
+    response_text: str = ""
+
+    # Error tracking (None unless a node failed).
+    error: str | None = None

--- a/src/ui/chat_app/graph/state.py
+++ b/src/ui/chat_app/graph/state.py
@@ -44,6 +44,10 @@ class GraphState(BaseModel):
     month: str | None = None
     postal_code: int | None = None
 
+    # Set by the parse node to explain an out_of_scope or error verdict, so the
+    # narrate node can decline with a reason rather than a generic message.
+    parse_reasoning: str | None = None
+
     # Output of the postal lookup (None unless a postal code was given and resolved).
     resolved_town: str | None = None
 

--- a/src/ui/chat_app/streamlit_app.py
+++ b/src/ui/chat_app/streamlit_app.py
@@ -1,16 +1,24 @@
 """Streamlit chat UI for HDB resale price prediction.
 
-Users describe a flat in natural language; Claude Haiku extracts the required
-fields via tool use and calls the FastAPI prediction service through
-:mod:`ui.chat_app.chat_agent`. The model never runs in this process.
+Users describe a flat in natural language. Each message is run through the
+LangGraph orchestration graph (:mod:`ui.chat_app.graph`), which parses the
+fields, resolves any postal code, predicts and explains via the in-process MCP
+tools, and narrates the reply — all behind one ``ainvoke`` call. The model never
+runs in this process.
+
+Each user message starts a fresh graph invocation: the graph is stateless per
+turn. Streamlit's session state holds the visible conversation history, but the
+parse node only ever sees the latest message. Multi-turn awareness is a
+deliberate non-goal for this phase.
 """
 
+import asyncio
 import logging
 
 import streamlit as st
 
-from ui.chat_app.chat_agent import chat_turn
 from ui.chat_app.config import ChatConfig
+from ui.chat_app.graph import GraphState, build_graph
 
 logger = logging.getLogger(__name__)
 
@@ -34,34 +42,48 @@ st.caption(
     "Describe a flat in plain English — e.g. *'3-room in Tampines, 90 sqm, lease started 1992'*"
 )
 
-# history: raw Anthropic-format messages (sent to the API each turn)
-# display: (role, text) tuples for rendering the conversation
-if "history" not in st.session_state:
-    st.session_state.history = []
-if "display" not in st.session_state:
-    st.session_state.display = []
+# Compile the graph once per session. Streamlit reruns the script top to bottom on
+# every interaction, so caching the compiled graph in session state avoids
+# rebuilding it on each message.
+if "graph" not in st.session_state:
+    st.session_state.graph = build_graph()
 
-for role, text in st.session_state.display:
+# messages: (role, text) tuples for rendering the conversation.
+if "messages" not in st.session_state:
+    st.session_state.messages = []
+
+for role, text in st.session_state.messages:
     with st.chat_message(role):
         st.markdown(text)
 
+
+def _run_turn(message: str) -> str:
+    """Invoke the graph for one user message and return the narrated reply.
+
+    Streamlit runs synchronously, so the async graph is driven via
+    ``asyncio.run``. Per Day 1's note, ``ainvoke`` returns a plain dict, which is
+    reconstructed into a :class:`GraphState` to read ``response_text`` with type
+    safety.
+    """
+    result = asyncio.run(st.session_state.graph.ainvoke(GraphState(user_message=message)))
+    return GraphState(**result).response_text
+
+
 if prompt := st.chat_input("Ask about an HDB flat..."):
-    st.session_state.display.append(("user", prompt))
+    st.session_state.messages.append(("user", prompt))
     with st.chat_message("user"):
         st.markdown(prompt)
-
-    st.session_state.history.append({"role": "user", "content": prompt})
 
     with st.chat_message("assistant"):
         with st.spinner("Thinking..."):
             try:
-                st.session_state.history, reply = chat_turn(st.session_state.history)
+                reply = _run_turn(prompt)
             except Exception as exc:
-                logger.exception("chat_turn failed")
+                logger.exception("graph invocation failed")
                 reply = f"Sorry, something went wrong: `{exc}`"
         st.markdown(reply)
 
-    st.session_state.display.append(("assistant", reply))
+    st.session_state.messages.append(("assistant", reply))
 
 with st.sidebar:
     st.subheader("About")
@@ -72,6 +94,5 @@ with st.sidebar:
         "Predictions are estimates; actual prices may vary."
     )
     if st.button("Clear conversation"):
-        st.session_state.history = []
-        st.session_state.display = []
+        st.session_state.messages = []
         st.rerun()

--- a/src/ui/chat_app/streamlit_app.py
+++ b/src/ui/chat_app/streamlit_app.py
@@ -16,20 +16,31 @@ import asyncio
 import logging
 
 import streamlit as st
+from pydantic import ValidationError
 
 from ui.chat_app.config import ChatConfig
 from ui.chat_app.graph import GraphState, build_graph
 
 logger = logging.getLogger(__name__)
 
-_config = ChatConfig()
+# Load configuration through ChatConfig so the key resolves from either the
+# environment or a .env file at the project root — the whole point of Pydantic
+# Settings. Reading os.environ directly here would defeat that and report the
+# key as missing whenever it lives only in .env.
+_KEY_HELP = (
+    "Set `ANTHROPIC_API_KEY` in your environment, or add it to a `.env` "
+    "file in the project root:\n\n"
+    "```\nANTHROPIC_API_KEY=sk-ant-...\n```"
+)
+
+try:
+    _config = ChatConfig()
+except ValidationError as exc:
+    st.error(f"**Could not load chat configuration.**\n\n```\n{exc}\n```\n\n{_KEY_HELP}")
+    st.stop()
+
 if not _config.anthropic_api_key:
-    st.error(
-        "**ANTHROPIC_API_KEY is not set.** "
-        "Export it in the same shell before launching:\n\n"
-        "```\nexport ANTHROPIC_API_KEY=sk-ant-...\n"
-        "streamlit run src/ui/chat_app/streamlit_app.py\n```"
-    )
+    st.error(f"**ANTHROPIC_API_KEY is not set.** {_KEY_HELP}")
     st.stop()
 
 st.set_page_config(

--- a/tests/ui/chat_app/graph/__init__.py
+++ b/tests/ui/chat_app/graph/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the LangGraph chat orchestration package."""

--- a/tests/ui/chat_app/graph/test_graph_branches.py
+++ b/tests/ui/chat_app/graph/test_graph_branches.py
@@ -1,0 +1,173 @@
+"""Routing tests for the compiled graph's conditional paths.
+
+These tests assert how the graph routes — which nodes run and what terminal
+status results — for each branch off the parse and validate decisions. The LLM
+nodes (parse, narrate) are replaced with deterministic doubles so the assertions
+turn on routing, not LLM phrasing; the LLM behaviour itself is unit-tested in
+``test_nodes``. The MCP-backed nodes get fake clients so no model or SQLite layer
+is needed.
+
+Patching ``parse.run`` / ``narrate.run`` and the per-node ``get_client`` must
+happen before ``build_graph``, because the compiled graph captures whatever those
+names point to at build time.
+"""
+
+from typing import Any
+
+import pytest
+
+from ui.chat_app.graph import GraphState, build_graph
+from ui.chat_app.graph.nodes import explain as explain_node
+from ui.chat_app.graph.nodes import lookup as lookup_node
+from ui.chat_app.graph.nodes import narrate as narrate_node
+from ui.chat_app.graph.nodes import parse as parse_node
+from ui.chat_app.graph.nodes import predict as predict_node
+
+_OTHER_FIELDS: dict[str, Any] = {
+    "flat_type": "4 ROOM",
+    "floor_area_sqm": 95.0,
+    "lease_commence_date": 1985,
+    "month": "2024-06",
+}
+_PREDICTION = {"predicted_resale_price": 586_888.0, "model_version": 7, "model_alias": "champion"}
+_EXPLANATION = {
+    "top_contributors": [{"feature": "Floor area (95 sqm)", "contribution": 40_000.0}],
+    "base_value": 400_000.0,
+}
+
+
+class _FakeClient:
+    """Async test double for MCPToolClient; records the predict kwargs it sees."""
+
+    def __init__(self, *, postal=None, prediction=None, explanation=None) -> None:
+        self._postal = postal
+        self._prediction = prediction
+        self._explanation = explanation
+        self.predict_kwargs: dict[str, Any] | None = None
+
+    async def lookup_postal_code(self, postal_code):
+        return self._postal
+
+    async def predict_price(self, **kwargs):
+        self.predict_kwargs = kwargs
+        return self._prediction
+
+    async def explain_prediction(self, **kwargs):
+        return self._explanation
+
+
+async def _deterministic_narrate(state: GraphState) -> dict:
+    """Stand-in narrate node: a fixed phrasing per terminal status."""
+    if state.status == "needs_follow_up":
+        return {"response_text": "Please provide: " + ", ".join(state.missing_fields)}
+    if state.status == "out_of_scope":
+        return {"response_text": f"Sorry, out of scope: {state.parse_reasoning}"}
+    if state.status == "error":
+        return {"response_text": "Sorry, something went wrong. Please try again."}
+    return {"response_text": f"Predicted S${state.predicted_price:,.0f}"}
+
+
+def _stub_parse(monkeypatch, fields: dict[str, Any]) -> None:
+    async def parse(state: GraphState) -> dict:
+        return fields
+
+    monkeypatch.setattr(parse_node, "run", parse)
+
+
+@pytest.fixture(autouse=True)
+def _stub_narrate(monkeypatch):
+    """Every branch test uses the deterministic narrate double."""
+    monkeypatch.setattr(narrate_node, "run", _deterministic_narrate)
+
+
+class TestMissingFieldsPath:
+    async def test_partial_extraction_routes_to_follow_up(self, monkeypatch) -> None:
+        _stub_parse(monkeypatch, {"town": "QUEENSTOWN", "flat_type": "4 ROOM", "status": "pending"})
+        graph = build_graph()
+        result = await graph.ainvoke(GraphState(user_message="4 room in queenstown"))
+        state = GraphState(**result)
+
+        assert state.status == "needs_follow_up"
+        assert state.predicted_price is None
+        assert set(state.missing_fields) == {"floor_area_sqm", "lease_commence_date", "month"}
+        assert state.response_text
+        assert "floor_area_sqm" in state.response_text
+
+
+class TestOutOfScopePath:
+    async def test_short_circuits_to_decline(self, monkeypatch) -> None:
+        _stub_parse(
+            monkeypatch,
+            {"status": "out_of_scope", "parse_reasoning": "condominiums are not HDB flats"},
+        )
+        graph = build_graph()
+        result = await graph.ainvoke(GraphState(user_message="3 bedroom condo in newton"))
+        state = GraphState(**result)
+
+        assert state.status == "out_of_scope"
+        assert state.predicted_price is None
+        assert state.missing_fields == []
+        assert "out of scope" in state.response_text
+
+
+class TestPredictToolFailurePath:
+    async def test_prediction_fault_becomes_error(self, monkeypatch) -> None:
+        _stub_parse(
+            monkeypatch,
+            {"town": "TAMPINES", "status": "pending", **_OTHER_FIELDS},
+        )
+
+        class _Boom(_FakeClient):
+            async def predict_price(self, **kwargs):
+                raise RuntimeError("predict tool down")
+
+        monkeypatch.setattr(predict_node, "get_client", lambda: _Boom())
+        graph = build_graph()
+        result = await graph.ainvoke(GraphState(user_message="tampines 4 room ..."))
+        state = GraphState(**result)
+
+        assert state.status == "error"
+        assert state.predicted_price is None
+        assert state.error is not None and "predict tool down" in state.error
+        assert state.response_text == "Sorry, something went wrong. Please try again."
+
+
+class TestPostalLookupMissPath:
+    async def test_unresolved_postal_with_no_town_needs_follow_up(self, monkeypatch) -> None:
+        # Postal code given but no explicit town; the lookup returns None.
+        _stub_parse(
+            monkeypatch,
+            {"postal_code": 999999, "status": "pending", **_OTHER_FIELDS},
+        )
+        monkeypatch.setattr(lookup_node, "get_client", lambda: _FakeClient(postal=None))
+        graph = build_graph()
+        result = await graph.ainvoke(GraphState(user_message="4 room, postal 999999"))
+        state = GraphState(**result)
+
+        assert state.status == "needs_follow_up"
+        assert state.resolved_town is None
+        assert state.missing_fields == ["town"]
+
+
+class TestPostalLookupSuccessPath:
+    async def test_resolved_town_drives_the_prediction(self, monkeypatch) -> None:
+        # Postal code only, no explicit town; the lookup resolves it to Bedok.
+        _stub_parse(
+            monkeypatch,
+            {"postal_code": 460001, "status": "pending", **_OTHER_FIELDS},
+        )
+        lookup_client = _FakeClient(postal={"town": "BEDOK"})
+        predict_client = _FakeClient(prediction=_PREDICTION, explanation=_EXPLANATION)
+        monkeypatch.setattr(lookup_node, "get_client", lambda: lookup_client)
+        monkeypatch.setattr(predict_node, "get_client", lambda: predict_client)
+        monkeypatch.setattr(explain_node, "get_client", lambda: predict_client)
+        graph = build_graph()
+        result = await graph.ainvoke(GraphState(user_message="4 room, postal 460001"))
+        state = GraphState(**result)
+
+        assert state.status == "ready_to_predict"
+        assert state.resolved_town == "BEDOK"
+        assert state.predicted_price == 586_888.0
+        # The prediction used the looked-up town, not a null explicit town.
+        assert predict_client.predict_kwargs is not None
+        assert predict_client.predict_kwargs["town"] == "BEDOK"

--- a/tests/ui/chat_app/graph/test_graph_e2e.py
+++ b/tests/ui/chat_app/graph/test_graph_e2e.py
@@ -1,0 +1,73 @@
+"""End-to-end graph traversal tests.
+
+The happy path runs the compiled graph against the real MCP predict and explain
+tools, with a StubModelLoader standing in for the @champion model so the test is
+hermetic. The postal lookup hits the real (committed) lookup table; the stub
+parse supplies postal 528003, which is absent from that table, so the lookup
+no-ops and the explicit town carries the prediction. The missing-fields path
+swaps in a parse stub that returns only a partial extraction and asserts the
+graph short-circuits past prediction straight to narration.
+"""
+
+import pytest
+
+import mcp_server.tools.predict as predict_mod
+from tests.conftest import (
+    StubModelLoader,
+    build_fixture_explainer_bundle,
+    build_fixture_pipeline,
+    make_synthetic_features,
+)
+from ui.chat_app.graph import GraphState, build_graph
+from ui.chat_app.graph.nodes import parse as parse_node
+
+
+@pytest.fixture
+def stub_loader(monkeypatch):
+    """Inject a StubModelLoader so the MCP predict/explain tools need no MLflow."""
+    X, y = make_synthetic_features(n=80)
+    pipeline = build_fixture_pipeline()
+    pipeline.fit(X, y)
+    bundle = build_fixture_explainer_bundle(pipeline)
+    stub = StubModelLoader(model=pipeline, version=7, explainer=bundle)
+    monkeypatch.setattr(predict_mod, "_loader", stub)
+    return stub
+
+
+class TestHappyPath:
+    async def test_full_traversal_predicts_and_narrates(self, stub_loader) -> None:
+        graph = build_graph()
+        result = await graph.ainvoke(
+            GraphState(user_message="3 room flat in Tampines, postal 528003")
+        )
+        state = GraphState(**result)
+
+        assert state.status == "ready_to_predict"
+        assert state.predicted_price is not None
+        assert 100_000 < state.predicted_price < 1_000_000
+        assert state.model_version == 7
+        assert state.base_value is not None
+        assert state.top_contributors
+        assert state.error is None
+        assert "Predicted price" in state.response_text
+
+
+class TestMissingFieldsPath:
+    async def test_short_circuits_to_narrate(self, monkeypatch) -> None:
+        async def partial_parse(state: GraphState) -> dict:
+            return {"town": "TAMPINES", "flat_type": "4 ROOM"}
+
+        # Patch before build_graph so the compiled graph captures the stub.
+        monkeypatch.setattr(parse_node, "run", partial_parse)
+        graph = build_graph()
+        result = await graph.ainvoke(GraphState(user_message="tampines 4 room"))
+        state = GraphState(**result)
+
+        assert state.status == "needs_follow_up"
+        assert state.predicted_price is None
+        assert set(state.missing_fields) == {
+            "floor_area_sqm",
+            "lease_commence_date",
+            "month",
+        }
+        assert state.response_text.startswith("Please provide")

--- a/tests/ui/chat_app/graph/test_graph_e2e.py
+++ b/tests/ui/chat_app/graph/test_graph_e2e.py
@@ -2,11 +2,12 @@
 
 The happy path runs the compiled graph against the real MCP predict and explain
 tools, with a StubModelLoader standing in for the @champion model so the test is
-hermetic. The postal lookup hits the real (committed) lookup table; the stub
-parse supplies postal 528003, which is absent from that table, so the lookup
-no-ops and the explicit town carries the prediction. The missing-fields path
-swaps in a parse stub that returns only a partial extraction and asserts the
-graph short-circuits past prediction straight to narration.
+hermetic. The parse and narrate nodes make live Anthropic calls in production, so
+both are stubbed here with deterministic doubles — these tests exercise the graph
+wiring and the MCP tool layer, not the LLM phrasing, which is unit-tested in
+``test_nodes`` with a mocked client. The missing-fields path swaps in a parse
+stub that returns only a partial extraction and asserts the graph short-circuits
+past prediction straight to narration.
 """
 
 import pytest
@@ -19,6 +20,7 @@ from tests.conftest import (
     make_synthetic_features,
 )
 from ui.chat_app.graph import GraphState, build_graph
+from ui.chat_app.graph.nodes import narrate as narrate_node
 from ui.chat_app.graph.nodes import parse as parse_node
 
 
@@ -34,8 +36,33 @@ def stub_loader(monkeypatch):
     return stub
 
 
+async def _canonical_parse(state: GraphState) -> dict:
+    """Deterministic stand-in for the LLM parse node: the standing test input."""
+    return {
+        "town": "TAMPINES",
+        "flat_type": "3 ROOM",
+        "floor_area_sqm": 95.0,
+        "lease_commence_date": 1985,
+        "month": "2024-06",
+        "postal_code": 528003,
+        "status": "pending",
+    }
+
+
+async def _deterministic_narrate(state: GraphState) -> dict:
+    """Deterministic stand-in for the LLM narrate node, echoing the prediction."""
+    return {
+        "response_text": (
+            f"Predicted price: S${state.predicted_price:,.0f} (model v{state.model_version})"
+        )
+    }
+
+
 class TestHappyPath:
-    async def test_full_traversal_predicts_and_narrates(self, stub_loader) -> None:
+    async def test_full_traversal_predicts_and_narrates(self, stub_loader, monkeypatch) -> None:
+        # Patch the LLM nodes before build_graph so the compiled graph captures them.
+        monkeypatch.setattr(parse_node, "run", _canonical_parse)
+        monkeypatch.setattr(narrate_node, "run", _deterministic_narrate)
         graph = build_graph()
         result = await graph.ainvoke(
             GraphState(user_message="3 room flat in Tampines, postal 528003")
@@ -57,8 +84,12 @@ class TestMissingFieldsPath:
         async def partial_parse(state: GraphState) -> dict:
             return {"town": "TAMPINES", "flat_type": "4 ROOM"}
 
-        # Patch before build_graph so the compiled graph captures the stub.
+        async def deterministic_narrate(state: GraphState) -> dict:
+            return {"response_text": "Please provide: " + ", ".join(state.missing_fields)}
+
+        # Patch before build_graph so the compiled graph captures the stubs.
         monkeypatch.setattr(parse_node, "run", partial_parse)
+        monkeypatch.setattr(narrate_node, "run", deterministic_narrate)
         graph = build_graph()
         result = await graph.ainvoke(GraphState(user_message="tampines 4 room"))
         state = GraphState(**result)

--- a/tests/ui/chat_app/graph/test_mcp_client.py
+++ b/tests/ui/chat_app/graph/test_mcp_client.py
@@ -1,0 +1,79 @@
+"""Tests for the in-process MCP client wrapper.
+
+predict and explain run against a StubModelLoader holding a fitted fixture
+pipeline and a real SHAP bundle — same injection the MCP tool tests use — so the
+wrapper exercises its full in-process Client path without an MLflow round-trip.
+The postal lookup uses the committed lookup table, so it is deterministic
+without a fixture.
+"""
+
+from typing import Any
+
+import pytest
+
+import mcp_server.tools.predict as predict_mod
+from tests.conftest import (
+    StubModelLoader,
+    build_fixture_explainer_bundle,
+    build_fixture_pipeline,
+    make_synthetic_features,
+)
+from ui.chat_app.graph.mcp_client import MCPToolClient, get_client
+
+_TAMPINES_4ROOM: dict[str, Any] = {
+    "town": "TAMPINES",
+    "flat_type": "4 ROOM",
+    "floor_area_sqm": 95.0,
+    "lease_commence_date": 1985,
+    "month": "2024-06",
+}
+
+
+@pytest.fixture
+def stub_loader(monkeypatch):
+    """Inject a StubModelLoader with a fitted fixture pipeline and explainer."""
+    X, y = make_synthetic_features(n=80)
+    pipeline = build_fixture_pipeline()
+    pipeline.fit(X, y)
+    bundle = build_fixture_explainer_bundle(pipeline)
+    stub = StubModelLoader(model=pipeline, version=7, explainer=bundle)
+    monkeypatch.setattr(predict_mod, "_loader", stub)
+    return stub
+
+
+class TestPredictPrice:
+    async def test_returns_structured_prediction(self, stub_loader) -> None:
+        client = MCPToolClient()
+        result = await client.predict_price(**_TAMPINES_4ROOM)
+        assert result["model_version"] == 7
+        assert result["model_alias"] == "champion"
+        assert 100_000 < result["predicted_resale_price"] < 1_000_000
+
+
+class TestExplainPrediction:
+    async def test_returns_contributors_and_base_value(self, stub_loader) -> None:
+        client = MCPToolClient()
+        result = await client.explain_prediction(**_TAMPINES_4ROOM)
+        assert isinstance(result["base_value"], float)
+        # The fixture's nine raw dummies aggregate to five source features.
+        assert len(result["top_contributors"]) == 5
+        for entry in result["top_contributors"]:
+            assert set(entry.keys()) == {"feature", "contribution"}
+
+
+class TestLookupPostalCode:
+    async def test_resolves_known_postal_to_town(self) -> None:
+        client = MCPToolClient()
+        result = await client.lookup_postal_code(522201)
+        assert result is not None
+        assert result["town"] == "TAMPINES"
+        assert result["street_full"] == "TAMPINES STREET 21"
+
+    async def test_unknown_postal_returns_none(self) -> None:
+        client = MCPToolClient()
+        assert await client.lookup_postal_code(999999) is None
+
+
+class TestSingleton:
+    def test_get_client_returns_same_instance(self) -> None:
+        assert get_client() is get_client()

--- a/tests/ui/chat_app/graph/test_nodes.py
+++ b/tests/ui/chat_app/graph/test_nodes.py
@@ -3,12 +3,16 @@
 The MCP-backed nodes (postal_lookup, predict, explain) call ``get_client()``;
 each test replaces it with a fake whose async methods return canned payloads or
 raise, so the node's own logic is exercised without the tool layer. The validate
-node is pure Python and needs no double.
+node is pure Python and needs no double. The LLM-backed nodes (parse, narrate)
+have their module-level ``_client`` patched with a mock returning canned message
+objects, so no live Anthropic call is made.
 """
 
+import json
 from typing import Any
+from unittest.mock import MagicMock
 
-from ui.chat_app.graph.nodes import explain, lookup, predict, validate
+from ui.chat_app.graph.nodes import explain, lookup, narrate, parse, predict, validate
 from ui.chat_app.graph.state import GraphState
 
 _READY_FIELDS: dict[str, Any] = {
@@ -169,3 +173,158 @@ class TestExplainNode:
     async def test_skips_when_not_ready(self) -> None:
         state = GraphState(user_message="x", status="needs_follow_up", predicted_price=500_000.0)
         assert await explain.run(state) == {}
+
+
+# ---------------------------------------------------------------------------
+# LLM node mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _llm_response(text: str) -> MagicMock:
+    """A mock Anthropic message whose single text block carries ``text``."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    msg = MagicMock()
+    msg.content = [block]
+    return msg
+
+
+def _mock_client(text: str) -> MagicMock:
+    """A mock Anthropic client whose ``messages.create`` returns ``text``."""
+    client = MagicMock()
+    client.messages.create.return_value = _llm_response(text)
+    return client
+
+
+def _parse_continuation(status: str, fields: dict[str, Any], reasoning: str = "ok") -> str:
+    """The text the model returns after the prefilled opening brace.
+
+    The parse node prepends ``{`` to the model's reply, so the mock must omit it.
+    """
+    payload = json.dumps({"status": status, "reasoning": reasoning, "fields": fields})
+    assert payload.startswith("{")
+    return payload[1:]
+
+
+_FULL_FIELDS = {
+    "town": "tampines",
+    "flat_type": "4 room",
+    "floor_area_sqm": 95.0,
+    "lease_commence_date": 1985,
+    "month": "2024-06",
+    "postal_code": None,
+}
+
+
+class TestParseNode:
+    async def test_extracts_and_normalises_fields(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            parse, "_client", _mock_client(_parse_continuation("extracted", _FULL_FIELDS))
+        )
+        result = await parse.run(GraphState(user_message="4 room flat in tampines, 95 sqm"))
+        assert result["status"] == "pending"
+        # Town and flat_type are uppercased to match the encoder vocabulary.
+        assert result["town"] == "TAMPINES"
+        assert result["flat_type"] == "4 ROOM"
+        assert result["floor_area_sqm"] == 95.0
+        assert result["lease_commence_date"] == 1985
+        assert result["month"] == "2024-06"
+        assert result["postal_code"] is None
+
+    async def test_out_of_scope_sets_status_and_reasoning(self, monkeypatch) -> None:
+        empty = dict.fromkeys(_FULL_FIELDS, None)
+        monkeypatch.setattr(
+            parse,
+            "_client",
+            _mock_client(_parse_continuation("out_of_scope", empty, reasoning="that is a condo")),
+        )
+        result = await parse.run(GraphState(user_message="how much for a condo in newton"))
+        assert result == {"status": "out_of_scope", "parse_reasoning": "that is a condo"}
+
+    async def test_malformed_json_sets_error_status(self, monkeypatch) -> None:
+        monkeypatch.setattr(parse, "_client", _mock_client("not valid json at all"))
+        result = await parse.run(GraphState(user_message="anything"))
+        assert result["status"] == "error"
+        assert result["parse_reasoning"]
+
+    async def test_api_failure_sets_error_status(self, monkeypatch) -> None:
+        client = MagicMock()
+        client.messages.create.side_effect = RuntimeError("api down")
+        monkeypatch.setattr(parse, "_client", client)
+        result = await parse.run(GraphState(user_message="anything"))
+        assert result["status"] == "error"
+        assert "api down" in result["parse_reasoning"]
+
+    async def test_null_town_is_left_as_none(self, monkeypatch) -> None:
+        fields = {**_FULL_FIELDS, "town": None}
+        monkeypatch.setattr(
+            parse, "_client", _mock_client(_parse_continuation("extracted", fields))
+        )
+        result = await parse.run(GraphState(user_message="a 4 room flat, 95 sqm"))
+        assert result["town"] is None
+
+
+_READY_STATE_KW: dict[str, Any] = {
+    "status": "ready_to_predict",
+    "predicted_price": 586_888.0,
+    "model_version": 7,
+    "top_contributors": [
+        {"feature": "Floor area (95 sqm)", "contribution": 40_000.0},
+        {"feature": "Town: Tampines", "contribution": 12_000.0},
+        {"feature": "Lease commence (1985)", "contribution": -8_000.0},
+    ],
+}
+
+
+class TestNarrateNode:
+    async def test_ready_branch_narrates_price(self, monkeypatch) -> None:
+        client = _mock_client("Your flat is worth about S$586,888.")
+        monkeypatch.setattr(narrate, "_client", client)
+        state = GraphState(user_message="x", **_READY_STATE_KW)
+        result = await narrate.run(state)
+        assert result == {"response_text": "Your flat is worth about S$586,888."}
+        # The contributors and price are passed to the model as context.
+        context = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "S$586,888" in context
+        assert "Floor area (95 sqm)" in context
+
+    async def test_follow_up_branch_lists_missing_fields(self, monkeypatch) -> None:
+        client = _mock_client("What's the floor area and lease year?")
+        monkeypatch.setattr(narrate, "_client", client)
+        state = GraphState(
+            user_message="x",
+            status="needs_follow_up",
+            missing_fields=["floor_area_sqm", "lease_commence_date"],
+        )
+        result = await narrate.run(state)
+        assert result == {"response_text": "What's the floor area and lease year?"}
+        context = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "floor area" in context
+
+    async def test_out_of_scope_branch_declines(self, monkeypatch) -> None:
+        client = _mock_client("I only cover HDB resale flats.")
+        monkeypatch.setattr(narrate, "_client", client)
+        state = GraphState(
+            user_message="x", status="out_of_scope", parse_reasoning="that is a condo"
+        )
+        result = await narrate.run(state)
+        assert result == {"response_text": "I only cover HDB resale flats."}
+
+    async def test_error_branch_apologises(self, monkeypatch) -> None:
+        client = _mock_client("Sorry, something went wrong. Please try again.")
+        monkeypatch.setattr(narrate, "_client", client)
+        state = GraphState(user_message="x", status="error", error="boom: internal detail")
+        result = await narrate.run(state)
+        assert result["response_text"] == "Sorry, something went wrong. Please try again."
+        # The raw internal error is never sent to the model.
+        context = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        assert "internal detail" not in context
+
+    async def test_llm_failure_falls_back_to_fixed_text(self, monkeypatch) -> None:
+        client = MagicMock()
+        client.messages.create.side_effect = RuntimeError("api down")
+        monkeypatch.setattr(narrate, "_client", client)
+        state = GraphState(user_message="x", **_READY_STATE_KW)
+        result = await narrate.run(state)
+        assert result["response_text"] == narrate._FALLBACK_ERROR

--- a/tests/ui/chat_app/graph/test_nodes.py
+++ b/tests/ui/chat_app/graph/test_nodes.py
@@ -1,0 +1,171 @@
+"""Happy-path and key-branch tests for the real nodes.
+
+The MCP-backed nodes (postal_lookup, predict, explain) call ``get_client()``;
+each test replaces it with a fake whose async methods return canned payloads or
+raise, so the node's own logic is exercised without the tool layer. The validate
+node is pure Python and needs no double.
+"""
+
+from typing import Any
+
+from ui.chat_app.graph.nodes import explain, lookup, predict, validate
+from ui.chat_app.graph.state import GraphState
+
+_READY_FIELDS: dict[str, Any] = {
+    "town": "TAMPINES",
+    "flat_type": "4 ROOM",
+    "floor_area_sqm": 95.0,
+    "lease_commence_date": 1985,
+    "month": "2024-06",
+}
+
+
+class _FakeClient:
+    """Async test double for MCPToolClient returning preset payloads."""
+
+    def __init__(self, *, postal=None, prediction=None, explanation=None) -> None:
+        self._postal = postal
+        self._prediction = prediction
+        self._explanation = explanation
+
+    async def lookup_postal_code(self, postal_code):
+        return self._postal
+
+    async def predict_price(self, **kwargs):
+        return self._prediction
+
+    async def explain_prediction(self, **kwargs):
+        return self._explanation
+
+
+class _BoomClient:
+    """Async test double whose every method raises, to drive the error branch."""
+
+    async def lookup_postal_code(self, postal_code):
+        raise RuntimeError("tool down")
+
+    async def predict_price(self, **kwargs):
+        raise RuntimeError("tool down")
+
+    async def explain_prediction(self, **kwargs):
+        raise RuntimeError("tool down")
+
+
+class TestPostalLookupNode:
+    async def test_resolves_town_from_result(self, monkeypatch) -> None:
+        monkeypatch.setattr(lookup, "get_client", lambda: _FakeClient(postal={"town": "TAMPINES"}))
+        state = GraphState(user_message="x", postal_code=522201)
+        assert await lookup.run(state) == {"resolved_town": "TAMPINES"}
+
+    async def test_no_postal_code_is_noop(self) -> None:
+        state = GraphState(user_message="x")
+        assert await lookup.run(state) == {}
+
+    async def test_not_found_is_noop(self, monkeypatch) -> None:
+        monkeypatch.setattr(lookup, "get_client", lambda: _FakeClient(postal=None))
+        state = GraphState(user_message="x", postal_code=999999)
+        assert await lookup.run(state) == {}
+
+    async def test_null_town_in_result_is_noop(self, monkeypatch) -> None:
+        monkeypatch.setattr(lookup, "get_client", lambda: _FakeClient(postal={"town": None}))
+        state = GraphState(user_message="x", postal_code=522201)
+        assert await lookup.run(state) == {}
+
+    async def test_tool_failure_sets_error_status(self, monkeypatch) -> None:
+        monkeypatch.setattr(lookup, "get_client", lambda: _BoomClient())
+        state = GraphState(user_message="x", postal_code=522201)
+        result = await lookup.run(state)
+        assert result["status"] == "error"
+        assert "tool down" in result["error"]
+
+
+class TestValidateNode:
+    async def test_all_fields_present_is_ready(self) -> None:
+        state = GraphState(user_message="x", **_READY_FIELDS)
+        assert await validate.run(state) == {
+            "missing_fields": [],
+            "status": "ready_to_predict",
+        }
+
+    async def test_resolved_town_satisfies_town_requirement(self) -> None:
+        fields = {**_READY_FIELDS}
+        del fields["town"]
+        state = GraphState(user_message="x", resolved_town="TAMPINES", **fields)
+        assert (await validate.run(state))["status"] == "ready_to_predict"
+
+    async def test_missing_fields_listed_for_follow_up(self) -> None:
+        state = GraphState(user_message="x", town="TAMPINES")
+        result = await validate.run(state)
+        assert result["status"] == "needs_follow_up"
+        assert set(result["missing_fields"]) == {
+            "flat_type",
+            "floor_area_sqm",
+            "lease_commence_date",
+            "month",
+        }
+
+    async def test_error_status_passes_through(self) -> None:
+        state = GraphState(user_message="x", status="error", error="boom")
+        assert await validate.run(state) == {}
+
+
+class TestPredictNode:
+    async def test_records_price_and_version(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            predict,
+            "get_client",
+            lambda: _FakeClient(
+                prediction={
+                    "predicted_resale_price": 500_000.0,
+                    "model_version": 7,
+                    "model_alias": "champion",
+                }
+            ),
+        )
+        state = GraphState(user_message="x", status="ready_to_predict", **_READY_FIELDS)
+        assert await predict.run(state) == {
+            "predicted_price": 500_000.0,
+            "model_version": 7,
+        }
+
+    async def test_skips_when_not_ready(self) -> None:
+        state = GraphState(user_message="x", status="needs_follow_up")
+        assert await predict.run(state) == {}
+
+    async def test_tool_failure_sets_error_status(self, monkeypatch) -> None:
+        monkeypatch.setattr(predict, "get_client", lambda: _BoomClient())
+        state = GraphState(user_message="x", status="ready_to_predict", **_READY_FIELDS)
+        result = await predict.run(state)
+        assert result["status"] == "error"
+        assert "tool down" in result["error"]
+
+
+class TestExplainNode:
+    async def test_records_contributors_and_base_value(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            explain,
+            "get_client",
+            lambda: _FakeClient(
+                explanation={
+                    "top_contributors": [{"feature": "Floor area", "contribution": 1.0}],
+                    "base_value": 400_000.0,
+                }
+            ),
+        )
+        state = GraphState(
+            user_message="x",
+            status="ready_to_predict",
+            predicted_price=500_000.0,
+            **_READY_FIELDS,
+        )
+        result = await explain.run(state)
+        assert result["base_value"] == 400_000.0
+        assert result["top_contributors"][0]["feature"] == "Floor area"
+
+    async def test_skips_without_a_prediction(self) -> None:
+        state = GraphState(user_message="x", status="ready_to_predict", predicted_price=None)
+        assert await explain.run(state) == {}
+
+    async def test_skips_when_not_ready(self) -> None:
+        state = GraphState(user_message="x", status="needs_follow_up", predicted_price=500_000.0)
+        assert await explain.run(state) == {}

--- a/tests/ui/chat_app/graph/test_state.py
+++ b/tests/ui/chat_app/graph/test_state.py
@@ -1,0 +1,85 @@
+"""Tests for the GraphState schema.
+
+Pure Pydantic behaviour — defaults, validation, and the model_copy(update=)
+pattern the graph relies on to produce a merged state between nodes.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from ui.chat_app.graph.state import GraphState, Status
+
+
+class TestDefaults:
+    def test_optional_fields_default_to_none(self) -> None:
+        state = GraphState(user_message="hello")
+        assert state.town is None
+        assert state.flat_type is None
+        assert state.floor_area_sqm is None
+        assert state.lease_commence_date is None
+        assert state.month is None
+        assert state.postal_code is None
+        assert state.resolved_town is None
+        assert state.predicted_price is None
+        assert state.model_version is None
+        assert state.base_value is None
+        assert state.error is None
+
+    def test_collection_and_status_defaults(self) -> None:
+        state = GraphState(user_message="hello")
+        assert state.missing_fields == []
+        assert state.top_contributors == []
+        assert state.response_text == ""
+        assert state.status == "pending"
+
+    def test_list_defaults_are_not_shared_between_instances(self) -> None:
+        first = GraphState(user_message="a")
+        second = GraphState(user_message="b")
+        first.missing_fields.append("town")
+        assert second.missing_fields == []
+
+
+class TestValidation:
+    def test_user_message_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            GraphState()  # type: ignore[call-arg]
+
+    def test_status_rejects_unknown_value(self) -> None:
+        with pytest.raises(ValidationError):
+            GraphState(user_message="x", status="bogus")  # type: ignore[arg-type]
+
+    def test_status_accepts_each_known_value(self) -> None:
+        statuses: tuple[Status, ...] = (
+            "pending",
+            "ready_to_predict",
+            "needs_follow_up",
+            "out_of_scope",
+            "error",
+        )
+        for status in statuses:
+            assert GraphState(user_message="x", status=status).status == status
+
+    def test_floor_area_int_coerced_to_float(self) -> None:
+        state = GraphState(user_message="x", floor_area_sqm=95)
+        assert state.floor_area_sqm == 95.0
+        assert isinstance(state.floor_area_sqm, float)
+
+
+class TestModelCopyUpdate:
+    def test_update_returns_new_state_with_changed_field(self) -> None:
+        original = GraphState(user_message="x")
+        updated = original.model_copy(update={"town": "TAMPINES"})
+        assert updated.town == "TAMPINES"
+
+    def test_update_leaves_original_unchanged(self) -> None:
+        original = GraphState(user_message="x")
+        original.model_copy(update={"town": "TAMPINES"})
+        assert original.town is None
+
+    def test_update_merges_multiple_fields(self) -> None:
+        original = GraphState(user_message="x")
+        updated = original.model_copy(
+            update={"status": "ready_to_predict", "predicted_price": 500_000.0}
+        )
+        assert updated.status == "ready_to_predict"
+        assert updated.predicted_price == 500_000.0

--- a/tests/ui/chat_app/test_config.py
+++ b/tests/ui/chat_app/test_config.py
@@ -1,0 +1,38 @@
+"""Tests for ChatConfig loading the Anthropic API key.
+
+The chat app resolves ANTHROPIC_API_KEY through ChatConfig so the key works
+whether it is exported in the shell or written to a .env file at the project
+root. The env_file is resolved relative to the working directory, so these
+tests change into a tmp_path holding a fixture .env.
+"""
+
+from ui.chat_app.config import ChatConfig
+
+
+def test_key_loaded_from_dotenv_when_env_var_absent(tmp_path, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-ant-from-dotenv\n")
+    monkeypatch.chdir(tmp_path)
+
+    config = ChatConfig()
+
+    assert config.anthropic_api_key == "sk-ant-from-dotenv"
+
+
+def test_env_var_takes_precedence_over_dotenv(tmp_path, monkeypatch):
+    (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-ant-from-dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-from-env")
+
+    config = ChatConfig()
+
+    assert config.anthropic_api_key == "sk-ant-from-env"
+
+
+def test_key_empty_when_neither_env_var_nor_dotenv_present(tmp_path, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    config = ChatConfig()
+
+    assert config.anthropic_api_key == ""


### PR DESCRIPTION
- **chore(deps): add langgraph~=1.2 for Phase 1.6c orchestration**
- **feat(chat): add GraphState schema for LangGraph orchestration**
- **feat(chat): add in-process MCP client wrapper for graph nodes**
- **feat(chat): add the six orchestration nodes**
- **feat(chat): wire the orchestration graph**
- **test(chat): cover GraphState, MCP client wrapper, nodes, and graph e2e**
- **feat(chat): replace parse stub with real Haiku field extraction**
- **feat(chat): replace narrate stub with real Haiku narration**
- **feat(chat): drive Streamlit through the orchestration graph**
- **test(chat): cover graph branches and the real LLM nodes**
- **docs(chat): document LangGraph orchestration in README and ADR 0004**
- **docs(chat): refresh the tested-modules table to 239 tests**
- **fix(chat_app): read ANTHROPIC_API_KEY via ChatConfig not os.environ**
