### PR TITLE
feat(docker): containerise FastAPI serving with multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Version control and tooling caches
+.git/
+.venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+*.pyc
+*.egg-info/
+
+# Secrets and local environment
+.env
+.env.local
+
+# Not needed to build or run the serving image
+tests/
+docs/
+notebooks/
+scripts/
+infra/
+data/
+
+# Provided at runtime via bind mounts (Session A) or the tracking server
+# (Session B) — never baked into the image
+mlruns/
+mlartifacts/
+mlflow.db
+mlflow.db-journal
+
+# Editor and OS noise
+.DS_Store
+.vscode/
+.idea/
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Multi-stage build for the FastAPI prediction service.
+#
+# The builder stage installs runtime dependencies into an isolated virtualenv
+# using uv. The runtime stage copies only that virtualenv plus the application
+# source, so the final image carries no build tools, no compilers, and no
+# dev/test dependencies. See docs/adr/0005-multi-stage-dockerfile-with-uv.md.
+
+FROM python:3.12-slim AS builder
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+# Only pyproject.toml is needed to resolve and install runtime dependencies.
+# The application source is deliberately not copied here: dependencies change
+# rarely while source changes often, so isolating this layer keeps the cache
+# warm across most rebuilds. Installing "." with no source present builds a
+# metadata-only wheel — the [project.dependencies] are installed, the package
+# itself contributes nothing. The source arrives in the runtime stage instead.
+COPY pyproject.toml ./
+RUN uv venv /opt/venv && \
+    VIRTUAL_ENV=/opt/venv uv pip install --no-cache .
+
+FROM python:3.12-slim
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY src/ /app/src/
+
+# Defaults to the SQLite registry bind-mounted at runtime. Session B overrides
+# this to point at the containerised MLflow tracking server over HTTP.
+ENV MLFLOW_TRACKING_URI=sqlite:////app/mlflow.db
+
+EXPOSE 8000
+
+# --app-dir puts /app/src on the import path so "serving.app" resolves without
+# editing PYTHONPATH or installing the package into the runtime image.
+CMD ["python", "-m", "uvicorn", "serving.app:app", \
+     "--host", "0.0.0.0", "--port", "8000", "--app-dir", "/app/src"]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,36 @@ curl -s -X POST http://localhost:8000/predict \
   | python -m json.tool
 ```
 
+### Try it via Docker (local)
+
+Phase 2 Session A containerises the FastAPI service as a multi-stage image. Build it:
+
+```bash
+docker build -t hdb-mlops:dev .
+```
+
+Run the container, bind-mounting your local MLflow registry. MLflow records artifact locations as absolute paths in `mlflow.db`, so `mlruns/` is mounted at the *same absolute path* it occupies on the host — that is what lets the in-container model loader resolve the `@champion` artifacts:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -v "$(pwd)/mlflow.db:/app/mlflow.db" \
+  -v "$(pwd)/mlruns:$(pwd)/mlruns" \
+  hdb-mlops:dev
+```
+
+The container spawns the background polling thread and loads `@champion` on startup — wait for the "Loaded hdb-predictor version N" log line. Then, from another terminal:
+
+```bash
+curl -s -X POST http://localhost:8000/predict \
+  -H "Content-Type: application/json" \
+  -d '{"town": "TAMPINES", "flat_type": "4 ROOM", "floor_area_sqm": 95.0, "lease_commence_date": 1985, "month": "2024-06"}' \
+  | python -m json.tool
+```
+
+Expect `predicted_resale_price` around `586900` with `model_version: 7`.
+
+Mounting the host's SQLite file and `mlruns/` directly is deliberately a Session A stopgap. Because artifact locations are absolute host paths, this run command is host-specific — fragile by design. Session B replaces it with `docker-compose` and a containerised MLflow tracking server, where FastAPI fetches artifacts over HTTP through the server's artifact proxy and never touches a host path. Session C adds GitHub Actions CI. See [docs/phase-2-design.md](docs/phase-2-design.md) and [docs/adr/0005-multi-stage-dockerfile-with-uv.md](docs/adr/0005-multi-stage-dockerfile-with-uv.md).
+
 ## What lives where
 
 ```

--- a/docs/adr/0005-multi-stage-dockerfile-with-uv.md
+++ b/docs/adr/0005-multi-stage-dockerfile-with-uv.md
@@ -1,0 +1,38 @@
+# ADR 0005: Multi-stage Dockerfile with uv
+
+**Status:** Accepted
+**Date:** 2026-06-16
+
+## Context
+
+Phase 1 through 1.6c ran the FastAPI prediction service as a local process on my Mac. Phase 2 containerises it. Issue #10 asks me to pin the serving environment so the libraries that serve a model match the ones that trained it — a containerised image is how I close that gap.
+
+Session A is the foundation: a single image that builds, runs, and serves a prediction. It deliberately stops short of docker-compose and a containerised MLflow tracking server (Session B) and CI (Session C). The container in this session talks to the host's existing `mlflow.db` and `mlruns/` through bind mounts, because standing up a real tracking service is Session B's job.
+
+Two forces shape the image. First, it ends up in CI on every PR, so build time and layer caching matter. Second, sklearn, SHAP, and NumPy are heavy native dependencies, so the choice of base image and how dependencies are installed determines whether the final image is 600MB or 1.5GB.
+
+## Decision
+
+I build the serving image with a multi-stage Dockerfile on `python:3.12-slim`, installing runtime dependencies with `uv` in the builder stage and copying only the resulting virtualenv plus the application source into the runtime stage.
+
+The runtime stage sets `MLFLOW_TRACKING_URI=sqlite:////app/mlflow.db` as a default and runs `python -m uvicorn serving.app:app --app-dir /app/src`. The `--app-dir` flag puts the source on the import path without installing the package or editing `PYTHONPATH`.
+
+## Consequences
+
+The runtime image carries no compilers, no `uv`, and none of the dev or test dependencies — only the virtualenv and the source under `/app/src`. That keeps the final image in the 500-800MB range despite sklearn and SHAP, versus the 1.5GB+ a single-stage build with build tooling retained would produce.
+
+Splitting dependency install from the source copy is a caching decision. Dependencies live in their own layer keyed on `pyproject.toml`; they only reinstall when that file changes. Editing `src/` invalidates only the cheap `COPY src/` layer, so the expensive sklearn/SHAP install is reused across the rebuilds that dominate day-to-day work and CI.
+
+The trade-off I am accepting in Session A: MLflow stores artifact locations as absolute filesystem paths in `mlflow.db`. Bind-mounting the host's `mlruns/` only resolves if the directory is mounted at the same absolute path the database recorded. That is fragile and host-specific — it is exactly the friction Session B removes by running an MLflow tracking server, where FastAPI fetches artifacts over HTTP through the server's artifact proxy and never touches a host path. Session A proves the service containerises; Session B makes the data plane portable.
+
+`MLFLOW_TRACKING_URI` defaults to the bind-mounted SQLite file so the image runs standalone. Session B overrides it to `http://mlflow:5000` via docker-compose, with no image rebuild — the registry endpoint is configuration, not a baked-in constant.
+
+## Alternatives considered
+
+**Single-stage build.** Simpler Dockerfile, one `FROM`. Rejected because the build tooling and uv stay in the final image, and without a clean dependency/source split the layer cache is far less effective. The size and CI-time cost outweigh the simplicity.
+
+**pip instead of uv.** pip is already in the base image, so it needs no bootstrap layer. I chose uv for consistency with the local development workflow established in Phase 1.6a — the same resolver and lockfile semantics in the container as on my machine — and for its faster cold installs, which matter on CI's uncached first build. The one extra `pip install uv` layer in the builder stage is a price paid in a stage that never ships.
+
+**A slimmer base — `alpine` or `distroless`.** Alpine uses musl libc, which forces source builds of NumPy, sklearn, and SHAP instead of the prebuilt manylinux wheels; the build gets slower and more fragile. Distroless removes the shell I want for debugging in this phase. `python:3.12-slim` is the sweet spot — Debian glibc means binary wheels install for both ARM64 and x86_64, while slim already strips the bulk of a full Debian image.
+
+**Installing the package into the runtime image** (`uv pip install .` with source present, then import normally). Rejected as unnecessary: the service is run directly from source, not imported as a library, so `--app-dir /app/src` is enough. Skipping the install avoids a build backend round-trip in the runtime stage and keeps the source copy as the only thing that changes between most rebuilds.


### PR DESCRIPTION
Phase 2 Session A: the foundation for the Docker/CI work.

- Multi-stage Dockerfile on python:3.12-slim. Builder installs runtime
  dependencies into a venv with uv; runtime copies only the venv and src/.
  Final image is ~317MB compressed / ~302MB per inspect — no build tools,
  no uv, no dev/test deps leak into the runtime stage.
- Runs uvicorn with --app-dir /app/src so serving.app resolves without
  installing the package or editing PYTHONPATH.
- MLFLOW_TRACKING_URI defaults to the bind-mounted SQLite registry; Session B
  overrides it to the containerised tracking server with no rebuild.
- .dockerignore keeps mlruns/, mlflow.db, tests, docs, and caches out of the
  build context.
- ADR 0005 records the multi-stage + uv + slim-base decision and the
  absolute-artifact-path fragility that Session B's tracking server removes.
- README gains a "Try it via Docker (local)" section.

Verified end to end: image builds, container loads @champion v7, and
/predict returns 586887.89 for the canonical Tampines payload. All 242
tests pass; pre-commit (ruff, ruff-format, mypy) clean. No retrain; v7
remains @champion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
