### PR TITLE
feat(docker): docker-compose with containerised MLflow tracking server (Phase 2 Session B)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,12 @@ WORKDIR /app
 
 COPY src/ /app/src/
 
-# Defaults to the SQLite registry bind-mounted at runtime. Session B overrides
-# this to point at the containerised MLflow tracking server over HTTP.
-ENV MLFLOW_TRACKING_URI=sqlite:////app/mlflow.db
+# Defaults to the containerised MLflow tracking server reachable on the compose
+# network. FastAPI fetches model artifacts over HTTP through the server's
+# artifact proxy and never reads the SQLite file or a host path directly. Local
+# standalone runs override this via shell env or .env. See
+# docs/adr/0006-mlflow-tracking-server-as-compose-service.md.
+ENV MLFLOW_TRACKING_URI=http://mlflow:5000
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,38 @@ curl -s -X POST http://localhost:8000/predict \
 
 Expect `predicted_resale_price` around `586900` with `model_version: 7`.
 
-Mounting the host's SQLite file and `mlruns/` directly is deliberately a Session A stopgap. Because artifact locations are absolute host paths, this run command is host-specific — fragile by design. Session B replaces it with `docker-compose` and a containerised MLflow tracking server, where FastAPI fetches artifacts over HTTP through the server's artifact proxy and never touches a host path. Session C adds GitHub Actions CI. See [docs/phase-2-design.md](docs/phase-2-design.md) and [docs/adr/0005-multi-stage-dockerfile-with-uv.md](docs/adr/0005-multi-stage-dockerfile-with-uv.md).
+Mounting the host's SQLite file and `mlruns/` directly is deliberately a Session A stopgap. Because artifact locations are absolute host paths, this run command is host-specific — fragile by design. The "Try it via Docker Compose" section below replaces it with the portable two-service story. Session C adds GitHub Actions CI. See [docs/phase-2-design.md](docs/phase-2-design.md) and [docs/adr/0005-multi-stage-dockerfile-with-uv.md](docs/adr/0005-multi-stage-dockerfile-with-uv.md).
+
+### Try it via Docker Compose
+
+Compose brings up the platform the way a real deployment runs it: FastAPI as one service, MLflow as a separate tracking server on port 5000, talking over HTTP. FastAPI fetches model artifacts through the tracking server's artifact proxy and never reads the registry database or a host path directly — the fragility of the Session A bind-mount is gone. See [docs/adr/0006-mlflow-tracking-server-as-compose-service.md](docs/adr/0006-mlflow-tracking-server-as-compose-service.md).
+
+One-time migration if your `mlflow.db` was built by local-process MLflow. MLflow records artifact locations as absolute host paths, which the containerised tracking server cannot serve. Rewrite them to portable `mlflow-artifacts:` proxy URIs once — the script is idempotent:
+
+```bash
+python scripts/migrate_artifact_paths_to_proxy.py
+```
+
+Then bring the stack up:
+
+```bash
+docker compose up -d --build
+```
+
+Wait for both services to report healthy, then predict against the FastAPI container:
+
+```bash
+docker compose ps
+
+curl -s -X POST http://localhost:8000/predict \
+  -H "Content-Type: application/json" \
+  -d '{"town": "TAMPINES", "flat_type": "4 ROOM", "floor_area_sqm": 95.0, "lease_commence_date": 1985, "month": "2024-06"}' \
+  | python -m json.tool
+```
+
+Expect `predicted_resale_price` around `586888` with `model_version: 1`. The MLflow UI is at [http://localhost:5000](http://localhost:5000). Tear down with `docker compose down`.
+
+On macOS, port 5000 is taken by the AirPlay Receiver by default — either turn it off under System Settings, General, AirDrop & Handoff, or remap the host port in a local compose override. The container-internal `http://mlflow:5000` that FastAPI uses is unaffected either way.
 
 ## What lives where
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v3.13.0
+    ports:
+      - "5000:5000"
+    # MLflow 3 rejects requests whose Host header is not on its DNS-rebinding
+    # allowlist, which defaults to localhost only. FastAPI reaches the server as
+    # http://mlflow:5000, so the service name must be allowlisted explicitly.
+    # localhost stays on the list because the healthcheck probes localhost:5000.
+    # Setting the env var replaces the default list, so both entries are required.
+    environment:
+      MLFLOW_SERVER_ALLOWED_HOSTS: "mlflow:5000,localhost:5000,127.0.0.1:5000"
+    volumes:
+      - ./mlflow.db:/mlflow/mlflow.db
+      - ./mlruns:/mlflow/artifacts
+    command: >
+      mlflow server
+      --host 0.0.0.0
+      --port 5000
+      --backend-store-uri sqlite:////mlflow/mlflow.db
+      --artifacts-destination /mlflow/artifacts
+      --serve-artifacts
+    # The official MLflow image ships no curl, so the healthcheck uses the
+    # Python interpreter already present in the image. urlopen exits non-zero
+    # on any status other than 2xx, which is the signal Compose needs.
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request, sys; sys.exit(0) if urllib.request.urlopen("http://localhost:5000/health").status == 200 else sys.exit(1)
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  fastapi:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow:5000
+    depends_on:
+      mlflow:
+        condition: service_healthy
+    # python:3.12-slim ships no curl either; reuse the interpreter-based probe.
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request, sys; sys.exit(0) if urllib.request.urlopen("http://localhost:8000/health").status == 200 else sys.exit(1)
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s

--- a/docs/adr/0005-multi-stage-dockerfile-with-uv.md
+++ b/docs/adr/0005-multi-stage-dockerfile-with-uv.md
@@ -25,7 +25,9 @@ Splitting dependency install from the source copy is a caching decision. Depende
 
 The trade-off I am accepting in Session A: MLflow stores artifact locations as absolute filesystem paths in `mlflow.db`. Bind-mounting the host's `mlruns/` only resolves if the directory is mounted at the same absolute path the database recorded. That is fragile and host-specific — it is exactly the friction Session B removes by running an MLflow tracking server, where FastAPI fetches artifacts over HTTP through the server's artifact proxy and never touches a host path. Session A proves the service containerises; Session B makes the data plane portable.
 
-`MLFLOW_TRACKING_URI` defaults to the bind-mounted SQLite file so the image runs standalone. Session B overrides it to `http://mlflow:5000` via docker-compose, with no image rebuild — the registry endpoint is configuration, not a baked-in constant.
+Session B has since landed and done exactly that — see [ADR 0006](0006-mlflow-tracking-server-as-compose-service.md). It also established that `--serve-artifacts` does not rewrite absolute paths already in the database, so the registry needed a one-time migration to `mlflow-artifacts:` proxy URIs on top of the tracking-server topology.
+
+`MLFLOW_TRACKING_URI` now defaults to `http://mlflow:5000` so the image runs correctly under compose out of the box; standalone local runs override it via shell env or `.env`, with no image rebuild — the registry endpoint is configuration, not a baked-in constant.
 
 ## Alternatives considered
 

--- a/docs/adr/0006-mlflow-tracking-server-as-compose-service.md
+++ b/docs/adr/0006-mlflow-tracking-server-as-compose-service.md
@@ -1,0 +1,40 @@
+# ADR 0006: MLflow tracking server as a docker-compose service
+
+**Status:** Accepted
+**Date:** 2026-06-16
+
+## Context
+
+Session A ([ADR 0005](0005-multi-stage-dockerfile-with-uv.md)) containerised the FastAPI prediction service as a single image that read the registry by bind-mounting the host's `mlflow.db` and `mlruns/` directly. Smoke testing exposed why that approach is a dead end. MLflow 3 records artifact locations as absolute host filesystem paths, and it does so in four tables, not one: `experiments.artifact_location`, `runs.artifact_uri`, `model_versions.storage_location`, and `logged_models.artifact_location`. When `mlflow.pyfunc.load_model("models:/hdb-predictor@champion")` runs inside a container, the client resolves the alias to a logged-model URI, reads `logged_models.artifact_location` — an absolute path like `/Users/cheeyoungchang/Projects/hdb-mlops-platform/mlruns/1/models/...` — and opens a *local* artifact repository against it. That path does not exist inside the container, so the load fails with `MlflowException: No such artifact: ''`. Bind-mounting `mlruns/` at the same absolute path the host uses papers over it, but only on my machine, and only until the path changes.
+
+The fix is to stop treating the registry as a file the serving container reads and start treating it as a service the serving container calls. That is the canonical MLflow deployment topology, and Session B adopts it.
+
+## Decision
+
+I run MLflow as its own docker-compose service — `ghcr.io/mlflow/mlflow:v3.13.0`, pinned — exposing the tracking and registry API on port 5000. FastAPI reaches it over HTTP at `http://mlflow:5000` via `MLFLOW_TRACKING_URI`; it never reads `mlflow.db` or a host path again. The tracking server runs with `--serve-artifacts` and `--artifacts-destination /mlflow/artifacts`, so artifacts flow through the same HTTP API as metadata, served from the server's own mounted filesystem. FastAPI requests `models:/hdb-predictor@champion`, the server resolves it internally and streams the model back over HTTP.
+
+SQLite remains the metadata backend, mounted at `sqlite:////mlflow/mlflow.db`; `mlruns/` is mounted at `/mlflow/artifacts`. `@champion` stays on version 1 — no retrain, no data migration.
+
+## Consequences
+
+FastAPI's data plane is now portable. The registry endpoint is configuration, not a baked-in path, so the same image runs unchanged against a local compose stack, a CI runner, or a future k3s deployment. This is what closes [#10](https://github.com/LEMSingapore/hdb-mlops-platform/issues/10): the tracking server is pinned to `v3.13.0` and FastAPI's image resolves `mlflow==3.13.0` through uv, so the library that serves a model and the library that trained it are byte-for-byte the same version on both sides of the wire.
+
+Three things this session surfaced that `--serve-artifacts` alone does not solve, and that the design note did not anticipate:
+
+**`--serve-artifacts` does not rewrite absolute paths already in the database.** The proxy only serves locations stored under the `mlflow-artifacts:` scheme. A pre-existing absolute path is handed to the client verbatim, which then falls back to the local artifact repository and fails exactly as before. The registry created by local-process MLflow therefore needs a one-time migration: `scripts/migrate_artifact_paths_to_proxy.py` rewrites the prefix up to and including `mlruns` to `mlflow-artifacts:` across all four tables, so `…/mlruns/1/models/m-abc/artifacts` becomes `mlflow-artifacts:/1/models/m-abc/artifacts`. With `mlruns/` mounted at `--artifacts-destination`, that URI resolves to the right file inside the server and streams over HTTP. The migration is idempotent and runs against the gitignored local `mlflow.db`; it is the documented prerequisite to bringing the stack up against a registry built before this ADR.
+
+**MLflow 3 rejects cross-service requests by default.** The server ships DNS-rebinding protection that validates the `Host` header against an allowlist defaulting to localhost only. FastAPI connects as `http://mlflow:5000`, so the request carries `Host: mlflow:5000` and is refused with a 403. I keep the protection on and set `MLFLOW_SERVER_ALLOWED_HOSTS` to an explicit allowlist — `mlflow:5000` for the service-to-service call plus `localhost:5000` and `127.0.0.1:5000` for browser and host access — rather than disabling it with a wildcard. Setting the variable replaces the default list, which is why localhost has to be restated.
+
+**Neither image ships `curl`.** The compose healthchecks therefore probe with the Python interpreter both images already carry, via `urllib.request`, instead of the `curl` the design sketch assumed.
+
+The trade-off I am accepting: SQLite as the metadata backend is safe only because this stack runs a single FastAPI replica and a single tracking server, so there are no concurrent writers. Horizontal scaling would force the canonical Postgres swap — the design doc records that path and Phase 6 owns it. The tracking server is also now a hard dependency of the serving container's startup; FastAPI fails fast if it cannot reach `http://mlflow:5000`, which is the correct behaviour but does make the tracking server a single point of failure. Production hardening of that SPOF — replicas, readiness probes, a managed backend — is Phase 6 work, not this PR's.
+
+## Alternatives considered
+
+**Bind-mount `mlruns/` at the host's absolute path inside the container.** This is the Session A stopgap. It works on exactly one machine, breaks the moment the repository moves, and cannot survive CI or a remote deployment where the host path is meaningless. Rejected as fundamentally non-portable — it is the problem this ADR exists to remove.
+
+**Rewrite stored paths to be relative and mount the artifact root identically in both containers, without `--serve-artifacts`.** This keeps clients reading artifacts off a shared filesystem instead of over HTTP. It would work for a co-located compose stack, but it re-couples the serving container to a filesystem layout and does not generalise to a deployment where FastAPI and MLflow do not share a volume. Serving artifacts over the API is the topology a real deployment uses, so I matched it now rather than carrying a shortcut into Phase 6.
+
+**Disable DNS-rebinding protection with `MLFLOW_SERVER_ALLOWED_HOSTS=*`.** Simpler — one token, no need to restate localhost. Rejected because an explicit allowlist is the same amount of configuration to reason about and keeps a real security control switched on. A wildcard would also read, to anyone scanning the compose file, as not having understood why the 403 happened.
+
+**Migrate the metadata backend to Postgres now.** The canonical production backend, and the obvious answer if I were scaling FastAPI past one replica. I am not, and the design doc explicitly defers it. Standing up a Postgres service for a single-writer registry is cost without benefit at this phase; it belongs to Phase 6 alongside the deployment that motivates it.

--- a/scripts/migrate_artifact_paths_to_proxy.py
+++ b/scripts/migrate_artifact_paths_to_proxy.py
@@ -1,0 +1,139 @@
+"""Rewrite absolute MLflow artifact paths to ``mlflow-artifacts:`` proxy URIs.
+
+Run once before bringing the docker-compose stack up against an ``mlflow.db``
+created by local-process MLflow:
+
+    python scripts/migrate_artifact_paths_to_proxy.py
+
+MLflow 3 records artifact locations as absolute host filesystem paths in four
+tables: ``experiments.artifact_location``, ``runs.artifact_uri``,
+``model_versions.storage_location`` and ``logged_models.artifact_location``.
+When the containerised tracking server hands one of those raw paths back to a
+client, the client opens a *local* artifact repository against a path that does
+not exist inside its container — the failure surfaces as
+``MlflowException: No such artifact: ''``. ``--serve-artifacts`` only proxies
+artifacts whose stored location already uses the ``mlflow-artifacts:`` scheme,
+so it does not rescue absolute paths on its own.
+
+This migration rewrites the prefix up to and including the ``mlruns`` directory
+to ``mlflow-artifacts:``, leaving the path that follows intact. With the
+tracking server started as ``--artifacts-destination /mlflow/artifacts`` and
+``./mlruns`` mounted at ``/mlflow/artifacts``, a stored
+``mlflow-artifacts:/1/models/m-abc/artifacts`` resolves to
+``/mlflow/artifacts/1/models/m-abc/artifacts`` and is served over HTTP. The
+client then uses the proxy artifact repository and never touches a host path.
+
+The script is idempotent: values already using the ``mlflow-artifacts:`` scheme
+are left untouched, so re-running it is a no-op. See
+docs/adr/0006-mlflow-tracking-server-as-compose-service.md for the rationale.
+"""
+
+import argparse
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).parent.parent
+_DEFAULT_DB_PATH = _REPO_ROOT / "mlflow.db"
+
+# The artifact root directory whose contents the tracking server proxies. Every
+# absolute path below this directory maps to a path under --artifacts-destination.
+_ARTIFACT_ROOT_DIRNAME = "mlruns"
+_PROXY_SCHEME = "mlflow-artifacts:"
+
+# (table, column) pairs that MLflow 3 populates with artifact locations.
+_TARGETS: list[tuple[str, str]] = [
+    ("experiments", "artifact_location"),
+    ("runs", "artifact_uri"),
+    ("model_versions", "storage_location"),
+    ("logged_models", "artifact_location"),
+]
+
+
+def _to_proxy_uri(value: str) -> str | None:
+    """Return the proxy-URI form of an absolute artifact path, or None to skip.
+
+    Returns None when the value is already a proxy URI or does not contain the
+    artifact root directory, so callers can distinguish "rewritten" from
+    "left alone".
+    """
+    if value.startswith(_PROXY_SCHEME):
+        return None
+    marker = f"/{_ARTIFACT_ROOT_DIRNAME}"
+    index = value.rfind(marker)
+    if index == -1:
+        return None
+    suffix = value[index + len(marker) :]
+    return f"{_PROXY_SCHEME}{suffix}"
+
+
+def migrate(db_path: Path) -> int:
+    """Rewrite absolute artifact paths in the database to proxy URIs.
+
+    Args:
+        db_path: Path to the MLflow SQLite backend store.
+
+    Returns:
+        The number of rows rewritten across all target tables.
+    """
+    if not db_path.exists():
+        raise FileNotFoundError(f"No MLflow database at {db_path}")
+
+    rewritten = 0
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        for table, column in _TARGETS:
+            values = {
+                row["value"]
+                for row in conn.execute(
+                    f"SELECT DISTINCT {column} AS value FROM {table} WHERE {column} IS NOT NULL"
+                ).fetchall()
+            }
+            for value in values:
+                proxy = _to_proxy_uri(value)
+                if proxy is None:
+                    continue
+                # Match on the stored value rather than rowid: some MLflow tables
+                # are declared WITHOUT ROWID, so rowid is not addressable.
+                cursor = conn.execute(
+                    f"UPDATE {table} SET {column} = ? WHERE {column} = ?",
+                    (proxy, value),
+                )
+                logger.info(
+                    "%s.%s (%d row(s)): %s -> %s",
+                    table,
+                    column,
+                    cursor.rowcount,
+                    value,
+                    proxy,
+                )
+                rewritten += cursor.rowcount
+        conn.commit()
+
+    logger.info("Rewrote %d artifact path(s) in %s", rewritten, db_path)
+    return rewritten
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "db_path",
+        nargs="?",
+        type=Path,
+        default=_DEFAULT_DB_PATH,
+        help=f"Path to the MLflow SQLite store (default: {_DEFAULT_DB_PATH})",
+    )
+    args = parser.parse_args()
+    try:
+        migrate(args.db_path)
+    except FileNotFoundError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Phase 2 Session B. Replaces the Session A standalone container — which read the registry by bind-mounting the host's `mlflow.db` and `mlruns/` at an absolute path — with a portable two-service `docker-compose` stack:

- **`mlflow`** — `ghcr.io/mlflow/mlflow:v3.13.0`, the tracking + registry API on port 5000, serving artifacts over HTTP via `--serve-artifacts`.
- **`fastapi`** — the prediction service, reaching MLflow at `http://mlflow:5000`. It fetches model artifacts through the server's artifact proxy and never reads the registry database or a host path directly.

This is the canonical MLflow deployment topology and removes the host-specific fragility ADR 0005 flagged.

## Why Session A's container couldn't load the model

Session A smoke testing failed with `MlflowException: No such artifact: ''`. MLflow 3 stores artifact locations as **absolute host filesystem paths** in four tables (`experiments`, `runs`, `model_versions`, `logged_models`), and the container can't resolve a host path. The tracking-server topology fixes this — but three MLflow 3 behaviours had to be handled, two of which the design note did not anticipate:

1. **`--serve-artifacts` does not rewrite absolute paths already in the database.** The proxy only serves `mlflow-artifacts:` locations; a pre-existing absolute path is handed to the client verbatim and falls back to the local artifact repo. `scripts/migrate_artifact_paths_to_proxy.py` rewrites the four tables to proxy URIs, once and idempotently.
2. **DNS-rebinding protection** rejects the cross-service `Host: mlflow:5000` header with a 403. Fixed with an explicit `MLFLOW_SERVER_ALLOWED_HOSTS` allowlist (kept on, not wildcarded).
3. **Neither image ships `curl`**, so healthchecks probe via the Python interpreter both images carry.

Full rationale in [ADR 0006](docs/adr/0006-mlflow-tracking-server-as-compose-service.md); ADR 0005 updated to note Session B landed.

## Verification (run end-to-end before opening)

```
docker compose ps      # both services healthy
curl /health           # 200 from both
POST /predict          # {"predicted_resale_price":586887.89,"model_version":1,"model_alias":"champion"}
MLflow UI              # 200
```

`@champion` remains version 1; no retrain. 242 tests pass; `pre-commit run --all-files` clean.

## Closes

Closes #10 — tracking server runs `mlflow 3.13.0` and FastAPI's image resolves the same `mlflow 3.13.0` via uv, so training and serving see byte-identical library versions.

## Notes

- On macOS, host port 5000 is taken by the AirPlay Receiver; the committed `5000:5000` mapping is correct for CI/Linux and other hosts. Documented in the README.
- Single FastAPI replica; SQLite metadata backend. Horizontal scaling and the Postgres swap are deferred to Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)