### PR TITLE
chore(docs): mark Phase 2 complete in build-plan

### DIFF
--- a/docs/build-plan.md
+++ b/docs/build-plan.md
@@ -98,6 +98,8 @@ Each phase has explicit acceptance criteria — a reviewer should be able to ver
 
 ### Phase 2 — Docker + Forgejo Actions CI (6-8 hours)
 
+**Status: complete** (Sessions A #37, B #38, C #41). Three deliberate deltas from the plan below, each recorded in an ADR. The MLflow backend stayed on SQLite rather than moving to Postgres + MinIO — the stack runs a single tracking server and a single FastAPI replica, so there are no concurrent writers, and the Postgres swap is the documented upgrade if that ever changes ([ADR 0006](adr/0006-mlflow-tracking-server-as-compose-service.md)). CI runs on GitHub Actions, not Forgejo — the workflows transfer 1:1, so this is the reversible convenience choice the note below anticipated. And CI verifies the image builds and runs end-to-end but does not push it to a registry; the push has no consumer until there is a deploy target, so it is deferred to Phase 6 ([ADR 0007](adr/0007-ci-workflow-and-registry-strategy.md)). CI seeds a synthetic `@champion` for its compose smoke test because the real artifact is too large to commit and the training data is not on the runner.
+
 **Scope:** Containerise everything. Wire up CI.
 
 **Deliverables:**


### PR DESCRIPTION
Marks Phase 2 (Docker + CI) complete in `docs/build-plan.md` now that Sessions A (#37), B (#38), and C (#41) have all merged.

Records the three deliberate deltas from the original plan, each backed by an ADR:

- **SQLite kept** over Postgres + MinIO — single tracking server, single FastAPI replica, no concurrent writers ([ADR 0006](docs/adr/0006-mlflow-tracking-server-as-compose-service.md)).
- **GitHub Actions** over Forgejo — workflows transfer 1:1; the reversible convenience choice the build-plan note anticipated.
- **No registry push** — CI proves the image builds and runs but does not publish it; deferred to Phase 6 when a deploy target consumes it ([ADR 0007](docs/adr/0007-ci-workflow-and-registry-strategy.md)).

Docs only. No code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)