### PR TITLE
feat(deploy): containerise Streamlit chat + public HTTPS routing (MVP Session 1c)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,3 +10,18 @@ hdb-mlops.duckdns.org {
 	# follow-up. FastAPI carries no LLM cost exposure, so the only exposure here
 	# is CPU, not spend.
 }
+
+hdb-mlops-chat.duckdns.org {
+	# Streamlit relies on a WebSocket (/_stcore/stream) for all client-server
+	# interaction. Caddy's reverse_proxy detects the Upgrade header and proxies
+	# the WebSocket transparently, so a plain reverse_proxy is sufficient — no
+	# explicit @websocket matcher or header handling is needed on this version.
+	reverse_proxy chat:8501
+
+	encode gzip
+
+	# Rate limiting omitted for the same reason as the main site: it needs an
+	# xcaddy custom build (tracked in issue #34). The LLM cost exposure on this
+	# surface is contained instead by the budget-capped Anthropic workspace and
+	# the chat's graceful degradation when the cap is hit.
+}

--- a/Dockerfile.chat
+++ b/Dockerfile.chat
@@ -1,0 +1,61 @@
+# Multi-stage build for the Streamlit chat UI.
+#
+# Mirrors the FastAPI Dockerfile: a builder stage installs runtime dependencies
+# into an isolated virtualenv with uv, and the runtime stage copies only that
+# virtualenv plus the application source. The chat bundles more than the API —
+# it imports the MCP server in-process (src/ui/chat_app -> mcp_server.server),
+# which pulls in the lookup, serving and data packages — but the dependency set
+# is identical because the whole project shares one pyproject.toml. See
+# docs/adr/0005-multi-stage-dockerfile-with-uv.md.
+
+FROM python:3.12-slim AS builder
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+# Only pyproject.toml is needed to resolve and install runtime dependencies.
+# Isolating this layer keeps the cache warm across source-only rebuilds, exactly
+# as in the FastAPI Dockerfile.
+COPY pyproject.toml ./
+RUN uv venv /opt/venv && \
+    VIRTUAL_ENV=/opt/venv uv pip install --no-cache .
+
+FROM python:3.12-slim
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY src/ /app/src/
+
+# The chat resolves postal codes through the in-process MCP lookup tool, which
+# imports lookup.postal. That module loads data/lookups/postal_codes.csv at
+# import time relative to the repo root (parents[2] of src/lookup/postal.py,
+# i.e. /app here), so the file must sit at /app/data/lookups/. It is the only
+# part of data/ the chat needs — the 162 MB SQLite transactions DB feeds the
+# find_similar tool, which the live graph never calls, and is excluded by
+# Dockerfile.chat.dockerignore. Without this CSV the chat would crash on
+# startup, since the load happens at import and is not behind the graph's
+# graceful-degradation path.
+COPY data/lookups/ /app/data/lookups/
+
+# Defaults to the containerised MLflow tracking server on the compose network.
+# The chat loads the @champion model in-process via the MCP predict/explain
+# tools, fetching artifacts over the server's HTTP proxy — never a host path.
+# See docs/adr/0006-mlflow-tracking-server-as-compose-service.md.
+ENV MLFLOW_TRACKING_URI=http://mlflow:5000
+
+EXPOSE 8501
+
+# --server.address 0.0.0.0 makes Streamlit reachable from Caddy over the compose
+# network. No --app-dir flag exists for streamlit, so PYTHONPATH puts /app/src on
+# the import path, mirroring how the FastAPI image resolves "serving.app".
+ENV PYTHONPATH=/app/src
+
+CMD ["streamlit", "run", "src/ui/chat_app/streamlit_app.py", \
+     "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/Dockerfile.chat.dockerignore
+++ b/Dockerfile.chat.dockerignore
@@ -1,0 +1,50 @@
+# Build-context ignore for Dockerfile.chat.
+#
+# BuildKit uses this file in place of .dockerignore when the build targets
+# Dockerfile.chat (it does not merge the two), so the full ignore list is
+# reproduced here. The one deliberate difference from .dockerignore: the chat
+# keeps data/lookups/ in the context, because lookup.postal loads
+# data/lookups/postal_codes.csv at import. Everything else under data/ stays
+# excluded — above all the 162 MB hdb.db, which only the unused find_similar
+# tool touches.
+
+# Version control and tooling caches
+.git/
+.venv/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+*.pyc
+*.egg-info/
+
+# Secrets and local environment — the API key reaches the container through the
+# compose environment, never baked into the image
+.env
+.env.local
+
+# Not needed to build or run the chat image
+tests/
+docs/
+notebooks/
+scripts/
+infra/
+
+# Heavy or runtime-only parts of data/. data/lookups/ is intentionally NOT listed
+# here so the postal_codes.csv the lookup tool needs stays in the build context.
+data/hdb.db
+data/*.db-journal
+data/raw/
+data/processed/
+
+# Provided at runtime by the tracking server — never baked into the image
+mlruns/
+mlartifacts/
+mlflow.db
+mlflow.db-journal
+
+# Editor and OS noise
+.DS_Store
+.vscode/
+.idea/
+.claude/

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -6,8 +6,12 @@
 # the runner host, so it re-publishes port 8000 here.
 #
 # CI also brings up only the mlflow and fastapi services (see ci.yml), never
-# Caddy, so no ACME TLS provisioning is attempted against a hostname that does
-# not resolve to the runner.
+# Caddy or chat. Caddy is excluded so no ACME TLS provisioning is attempted
+# against a hostname that does not resolve to the runner. Chat is excluded
+# because it needs an ANTHROPIC_API_KEY and exercises the LLM-calling parse and
+# narrate nodes — out of scope for a deterministic /predict smoke test. Both are
+# excluded simply by not being named in `up -d mlflow fastapi`, so neither is
+# built or started here.
 services:
   fastapi:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,40 @@ services:
       retries: 5
       start_period: 10s
 
+  chat:
+    build:
+      context: .
+      dockerfile: Dockerfile.chat
+    # No host port mapping: like fastapi, the chat is reached only through Caddy
+    # over the compose network as http://chat:8501. Publishing it to the host
+    # would bypass ufw, leaving the Streamlit port exposed behind only the cloud
+    # firewall. Caddy terminates TLS and is the sole public surface.
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow:5000
+      # Read from the shell environment or compose's auto-loaded .env, defaulting
+      # to empty. The :- default means the service still starts with no key
+      # present, running in graceful-degraded mode — the parse and narrate nodes
+      # already catch any Anthropic failure and fall back to fixed messages. This
+      # matters for the deploy sequence: the stack comes up first, the key lands
+      # on the box afterwards. Using `environment:` rather than `env_file: .env`
+      # also avoids the missing-file failure tracked in issue #29.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    depends_on:
+      mlflow:
+        condition: service_healthy
+    # python:3.12-slim ships no curl; reuse the interpreter-based probe pattern.
+    # Streamlit exposes /_stcore/health, which returns 200 once the server is up.
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request, sys; sys.exit(0) if urllib.request.urlopen("http://localhost:8501/_stcore/health").status == 200 else sys.exit(1)
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   caddy:
     image: caddy:2-alpine
     # The only service that publishes to the host. Caddy reverse-proxies to
@@ -75,6 +109,8 @@ services:
       - caddy_config:/config
     depends_on:
       fastapi:
+        condition: service_healthy
+      chat:
         condition: service_healthy
 
 volumes:


### PR DESCRIPTION
## What this is

MVP Session 1c from `docs/roadmap-v2-online-service.md`: package the existing LangGraph chat (`src/ui/chat_app/`) as a container and serve it publicly over HTTPS at `hdb-mlops-chat.duckdns.org`, behind the same Caddy reverse proxy already fronting FastAPI. The chat loads the `@champion` model in-process via the in-process MCP client (Option A) and calls Claude Haiku for the parse + narrate nodes.

**Packaging and routing only.** No `.py` files under `src/` were touched — chat logic, the graph, and the nodes (including the already-implemented graceful degradation) are unchanged.

## Changes

1. **`Dockerfile.chat`** — mirrors the FastAPI multi-stage `uv` build (`python:3.12-slim`, builder venv, runtime copies venv + `src/`). Same single `pyproject.toml`, so no new deps. Entrypoint: `streamlit run ... --server.port 8501 --server.address 0.0.0.0`. `MLFLOW_TRACKING_URI` defaults to `http://mlflow:5000`. It additionally bundles `data/lookups/postal_codes.csv` (see note below).
2. **`Dockerfile.chat.dockerignore`** — BuildKit per-Dockerfile ignore. Mirrors `.dockerignore` but keeps `data/lookups/` in the context while still excluding the 162 MB `data/hdb.db` and the rest of `data/`.
3. **`docker-compose.yml`** — new `chat` service: no host ports (Caddy reaches it as `chat:8501`), `MLFLOW_TRACKING_URI: http://mlflow:5000`, `ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}` (empty default so the stack starts keyless), `depends_on: mlflow service_healthy`, and a urllib `/_stcore/health` probe (image has no curl). Caddy now also waits on `chat` healthy.
4. **`Caddyfile`** — second site block `hdb-mlops-chat.duckdns.org` → `reverse_proxy chat:8501`, `encode gzip`. No `rate_limit` (needs xcaddy, tracked in #34).
5. **`docker-compose.ci.yml`** — comment only: documents that `chat`, like Caddy, is excluded from CI by not being named in `up -d mlflow fastapi`.

## Two things worth flagging

**The postal CSV must be in the image.** `lookup.postal` loads `data/lookups/postal_codes.csv` at *import* time, and that import runs at chat startup via `mcp_server.server`. It is **not** behind the graph's graceful-degradation path, so a missing CSV crashes the chat on boot. `.dockerignore` excludes all of `data/`, hence the dedicated `Dockerfile.chat.dockerignore` that carves out `data/lookups/` (614 KB) while keeping the 162 MB `hdb.db` out. The `find_similar` MCP tool (the only consumer of `hdb.db`) is not on the live graph path — only `lookup_postal_code`, `predict_price`, and `explain_prediction` are — so the DB is genuinely not needed by the chat.

**The `ANTHROPIC_API_KEY` env posture (re: #29).** Existing services use `environment:` literals, not `env_file:`. I followed that and used `environment: ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}`. Compose interpolates this from an auto-loaded `.env` if present, and defaults empty otherwise — so the service starts cleanly whether or not `.env` exists (no `env_file:` missing-file failure). This is important for the deploy sequence: the stack comes up first, the key is placed on the box afterwards, and until then the chat runs in graceful-degraded mode. **No `.env` or key is created or committed in this PR.**

## Future cleanup (not actioned here)

`src/ui/chat_app/chat_agent.py` and `predictor.py` carry a legacy tool-use path; the live graph only imports the constants (`MODEL`, `TOWNS`, `FLAT_TYPES`) from `chat_agent.py`. Leaving both as-is — removing the dead path is a separate cleanup.

## Verification

- `python -m pytest` — **242 passed** (no tested code changed).
- `pre-commit run --all-files` — ruff, ruff-format, mypy all **pass**.
- `docker compose config` and the CI merge `-f docker-compose.yml -f docker-compose.ci.yml config` both valid.
- Caddyfile `caddy adapt` parses; `caddy fmt --diff` clean.
- Chat image builds: **1.48 GB** — same as the FastAPI image, because both install the identical `pyproject.toml` dependency set; the chat adds only the 614 KB CSV. Verified in-container: `postal_codes.csv` present, `hdb.db` absent, `build_graph()` and the full import chain succeed without a live MLflow (model loads lazily at runtime), `ChatConfig().anthropic_api_key == ''` by default.
- **Streamlit WebSocket:** plain `reverse_proxy chat:8501` is sufficient. Caddy auto-detects the `Upgrade` header and proxies `/_stcore/stream` transparently — no `@websocket` matcher or explicit header handling needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)